### PR TITLE
Refactor : 회원가입 6자리인증번호 관련 로직수정

### DIFF
--- a/app/src/main/java/com/echoist/linkedout/page/login/SignUpPage.kt
+++ b/app/src/main/java/com/echoist/linkedout/page/login/SignUpPage.kt
@@ -498,12 +498,13 @@ fun Authentication_6_BottomModal(
 ) {
     // MutableStateList로 6자리 입력 값을 저장
     val codeDigits = remember { mutableStateListOf("", "", "", "", "", "") }
-
+    val keyboardController = LocalSoftwareKeyboardController.current
     val focusRequesters = List(6) { FocusRequester() }
 
     // 바텀시트가 다시 내려갔을 때 때 첫 번째 TextField에 포커스를 설정 && 텍스트필드값 초기화
     LaunchedEffect(scaffoldState.bottomSheetState.currentValue) {
         if (scaffoldState.bottomSheetState.currentValue == SheetValue.Hidden) {
+            keyboardController!!.hide()
             focusRequesters[0].requestFocus()
             codeDigits.clear()
             repeat(6) { codeDigits.add("") }
@@ -532,6 +533,10 @@ fun Authentication_6_BottomModal(
                     Authentication_TextField(
                         text = codeDigits[index], // 해당 인덱스의 값을 전달
                         onValueChange = { newValue ->
+                            if (newValue.isEmpty() && index > 0) {
+                                // 입력이 지워졌을 때 && 0번째 필드가 아니면 이전 TextField로 포커스 이동
+                                focusRequesters[index - 1].requestFocus()
+                            }
                             codeDigits[index] = newValue
                         },
                         focusRequester = focusRequesters[index],
@@ -597,7 +602,7 @@ fun Authentication_TextField(
 ) {
     OutlinedTextField(
         value = text,
-        onValueChange = {
+        onValueChange = { it->
             if (it.length <= 1) {
                 onValueChange(it) // 상위 컴포저블로 값 전달
                 if (it.isNotEmpty()) {

--- a/app/src/main/java/com/echoist/linkedout/page/login/SignUpPage.kt
+++ b/app/src/main/java/com/echoist/linkedout/page/login/SignUpPage.kt
@@ -207,7 +207,7 @@ fun SignUpPage(
                                 containerColor = LinkedInColor,
                                 disabledContainerColor = Color(0xFF868686)
                             ),
-                            enabled = !viewModel.userEmailError && viewModel.userPw.isNotEmpty(),
+                            enabled = !viewModel.userEmailError && viewModel.userPw.isNotEmpty() && !viewModel.isLoading,
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .height(100.dp)

--- a/app/src/main/java/com/echoist/linkedout/page/login/SignUpPage.kt
+++ b/app/src/main/java/com/echoist/linkedout/page/login/SignUpPage.kt
@@ -32,6 +32,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Done
 import androidx.compose.material3.BottomSheetScaffold
+import androidx.compose.material3.BottomSheetScaffoldState
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -132,7 +133,8 @@ fun SignUpPage(
                         keyboardController?.hide()
                         Log.d("6자리 코드 ", list.joinToString(""))
                         viewModel.requestRegister(list.joinToString(""), navController)
-                    }
+
+                    },scaffoldState
                 )
                 if (viewModel.isLoading) {
                     Box(
@@ -486,16 +488,27 @@ fun SendSignUpFinishedAlert(isClicked: () -> Unit, text1: String, text2: String)
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun Authentication_6_BottomModal(
     reAuthentication: () -> Unit,
     isError: Boolean,
     isTypedLastNumber: (List<String>) -> Unit,
+    scaffoldState : BottomSheetScaffoldState
 ) {
     // MutableStateList로 6자리 입력 값을 저장
     val codeDigits = remember { mutableStateListOf("", "", "", "", "", "") }
 
     val focusRequesters = List(6) { FocusRequester() }
+
+    // 바텀시트가 다시 내려갔을 때 때 첫 번째 TextField에 포커스를 설정 && 텍스트필드값 초기화
+    LaunchedEffect(scaffoldState.bottomSheetState.currentValue) {
+        if (scaffoldState.bottomSheetState.currentValue == SheetValue.Hidden) {
+            focusRequesters[0].requestFocus()
+            codeDigits.clear()
+            repeat(6) { codeDigits.add("") }
+        }
+    }
 
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,

--- a/app/src/main/java/com/echoist/linkedout/page/settings/ChangeEmailPage.kt
+++ b/app/src/main/java/com/echoist/linkedout/page/settings/ChangeEmailPage.kt
@@ -120,7 +120,7 @@ fun ChangeEmailPage(navController: NavController) {
                     isTypedLastNumber = { list -> //6자리 리스트
                         //todo 마지막 넘버 입력시 인증 함수 필요 및 isError지정
                         keyboardController?.hide()
-                    }
+                    },scaffoldState
                 )
                 if (viewModel.isLoading) {
                     Box(

--- a/app/src/main/java/com/echoist/linkedout/page/settings/ResetPwPageWithEmail.kt
+++ b/app/src/main/java/com/echoist/linkedout/page/settings/ResetPwPageWithEmail.kt
@@ -94,7 +94,7 @@ fun ResetPwPageWithEmail(navController: NavController) {
                     isError = false,
                     isTypedLastNumber = {
                         keyboardController?.hide()
-                    }
+                    },scaffoldState
                 )
                 if (viewModel.isLoading) {
                     Box(


### PR DESCRIPTION
- 키보드의 x키를 입력했을때 마지막필드가 아니라면 이전 텍스트필드의 focus로 이동함
- bottom sheet가 내려갔을 때 때 첫 번째 TextField에 포커스를 설정 && 텍스트필드값 초기화
- api 요청중일때 이메일인증 버튼 클릭 비활성화

https://github.com/user-attachments/assets/3bafc0f9-88bc-42f0-a086-b7ccfecf5e8b

