### PR TITLE
[FEAT] SignUpViewModel 정리

### DIFF
--- a/app/src/main/java/com/echoist/linkedout/Extensions.kt
+++ b/app/src/main/java/com/echoist/linkedout/Extensions.kt
@@ -1,0 +1,7 @@
+package com.echoist.linkedout
+
+import android.util.Patterns
+
+fun String.isEmailValid(): Boolean {
+    return Patterns.EMAIL_ADDRESS.matcher(this).matches()
+}

--- a/app/src/main/java/com/echoist/linkedout/api/SignUpApi.kt
+++ b/app/src/main/java/com/echoist/linkedout/api/SignUpApi.kt
@@ -13,52 +13,59 @@ interface SignUpApi {
         @Body email: EmailRequest
     ): Response<Unit>
 
-    data class EmailRequest(val email : String,val id : Int? = null)
+    data class EmailRequest(val email: String, val id: Int? = null)
+
     @POST("api/auth/sign")
     suspend fun emailVerify(
-        @Body userAccount : UserAccount
+        @Body userAccount: UserAccount
     ): Response<Unit>
 
     data class UserAccount(
         val email: String,
         val password: String,
         val birtDate: String = "",
-        val gender : String = "",
-        val oauthInfo : String = ""
+        val gender: String = "",
+        val oauthInfo: String = ""
     )
 
     //이메일 재설정
     @POST("api/auth/email/verify")
     suspend fun sendEmailVerificationForChange(
-        @Body email : EmailRequest
+        @Body email: EmailRequest
+    ): Response<Unit>
+
+    data class ChangeEmail(val code: String)
+    @POST("api/auth/email/change")
+    suspend fun postAuthChangeEmail(
+        @Body code: ChangeEmail
     ): Response<Unit>
 
     //비밀번호 재설정 요청
-    @POST("api/auth/password/reset-req")
+    @POST("api/auth/password/reset")
     suspend fun requestChangePw(
-        @Body email : EmailRequest
+        @Body email: EmailRequest
     ): Response<Unit>
 
     @POST("api/auth/password/reset-verify")
     suspend fun verifyChangePw(
-        @Query("token") token : String
+        @Query("token") token: String
     ): Response<Unit>
 
     @POST("api/auth/password/reset")
     suspend fun resetPw(
-        @Body resetPwRequest : ResetPwRequest
+        @Body resetPwRequest: ResetPwRequest
     ): Response<Unit>
 
-    data class ResetPwRequest(val pw : String,val token : String)
+    data class ResetPwRequest(val pw: String, val token: String)
 
     @POST("api/auth/login")
     suspend fun login(
-        @Body userAccount : UserAccount
+        @Body userAccount: UserAccount
     ): Response<TokensResponse>
 
     //6자리 코드 인증 후 회원가입 요청
     @POST("api/auth/register")
     suspend fun requestRegister(
-        @Body code : RegisterCode
+        @Body code: RegisterCode
     ): Response<TokensResponse>
 }

--- a/app/src/main/java/com/echoist/linkedout/api/SignUpApiImpl.kt
+++ b/app/src/main/java/com/echoist/linkedout/api/SignUpApiImpl.kt
@@ -29,6 +29,10 @@ class SignUpApiImpl : SignUpApi {
         TODO("Not yet implemented")
     }
 
+    override suspend fun postAuthChangeEmail(code: SignUpApi.ChangeEmail): Response<Unit> {
+        TODO("Not yet implemented")
+    }
+
     override suspend fun requestChangePw(
         email: SignUpApi.EmailRequest
     ): Response<Unit> {

--- a/app/src/main/java/com/echoist/linkedout/navigation/TabletNavHost.kt
+++ b/app/src/main/java/com/echoist/linkedout/navigation/TabletNavHost.kt
@@ -132,7 +132,13 @@ fun TabletNavHost(
             )
         }
         composable(Routes.ChangeEmail) {
-            TabletChangeEmailScreen(contentPadding = contentPadding)
+            TabletChangeEmailScreen(contentPadding = contentPadding) {
+                navController.navigate(Routes.LoginPage) {
+                    popUpTo(Routes.LoginPage) {
+                        inclusive = true
+                    }
+                }
+            }
         }
         composable(Routes.ChangePassword) {
             TabletChangePasswordScreen(

--- a/app/src/main/java/com/echoist/linkedout/page/login/AgreeOfProvisionsPage.kt
+++ b/app/src/main/java/com/echoist/linkedout/page/login/AgreeOfProvisionsPage.kt
@@ -232,7 +232,6 @@ fun AgreeOfProvisionsPage(navController: NavController, viewModel: SignUpViewMod
                             viewModel.agreement_location,
                             viewModel.agreement_marketing,
                             viewModel.agreement_serviceAlert,
-                            navController, //동의여부 서버에 보내고 첫 회원가입 로그인,
                             context
                         )
                     }

--- a/app/src/main/java/com/echoist/linkedout/page/login/SignUpComplete.kt
+++ b/app/src/main/java/com/echoist/linkedout/page/login/SignUpComplete.kt
@@ -46,9 +46,12 @@ fun SignUpCompletePage(homeViewModel: HomeViewModel, navController: NavControlle
         isLoading = true
         delay(3000)
         isLoading = false
-        navController.navigate("${Routes.Home}/200")
+        navController.navigate("${Routes.Home}/200") {
+            popUpTo(navController.graph.startDestinationId) {
+                inclusive = true
+            }
+        }
     }
-
 
     Scaffold {
         Box(

--- a/app/src/main/java/com/echoist/linkedout/page/login/SignUpPage.kt
+++ b/app/src/main/java/com/echoist/linkedout/page/login/SignUpPage.kt
@@ -74,6 +74,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
 import com.echoist.linkedout.R
+import com.echoist.linkedout.isEmailValid
 import com.echoist.linkedout.ui.theme.LinkedInColor
 import com.echoist.linkedout.viewModels.SignUpViewModel
 import kotlinx.coroutines.delay
@@ -318,7 +319,7 @@ fun EmailTextField(viewModel: SignUpViewModel, passwordFocusRequester: FocusRequ
             isError = viewModel.userEmailError,
             onValueChange = { new ->
                 viewModel.userEmail = new
-                if (new.isNotEmpty() && viewModel.isEmailValid(viewModel.userEmail)) {
+                if (new.isNotEmpty() && viewModel.userEmail.isEmailValid()) {
                     viewModel.userEmailError = false
                     errorText = ""
                 } else {

--- a/app/src/main/java/com/echoist/linkedout/page/login/SignUpPage.kt
+++ b/app/src/main/java/com/echoist/linkedout/page/login/SignUpPage.kt
@@ -168,10 +168,7 @@ fun SignUpPage(
                 })
             },
             content = {
-
-
                 Box {
-
                     Column(
                         modifier = Modifier
                             .fillMaxSize()
@@ -185,7 +182,11 @@ fun SignUpPage(
                             modifier = Modifier
                                 .padding(16.dp)
                                 .size(30.dp)
-                                .clickable { navController.popBackStack() } //뒤로가기
+                                .clickable {
+                                    navController.popBackStack()
+                                    viewModel.userEmail = ""
+                                    viewModel.userPw = ""
+                                }
                         )
                         Spacer(modifier = Modifier.height(30.dp))
                         Text(

--- a/app/src/main/java/com/echoist/linkedout/page/login/SignUpPage.kt
+++ b/app/src/main/java/com/echoist/linkedout/page/login/SignUpPage.kt
@@ -60,6 +60,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.rememberGraphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
@@ -509,7 +510,7 @@ fun Authentication_6_BottomModal(
     // MutableStateList로 6자리 입력 값을 저장
     val codeDigits = remember { mutableStateListOf("", "", "", "", "", "") }
     val keyboardController = LocalSoftwareKeyboardController.current
-    val focusRequesters = List(6) { FocusRequester() }
+    val focusRequesters = remember { List(6) { FocusRequester() } }
 
     // 바텀시트가 다시 내려갔을 때 때 첫 번째 TextField에 포커스를 설정 && 텍스트필드값 초기화
     LaunchedEffect(scaffoldState.bottomSheetState.currentValue) {

--- a/app/src/main/java/com/echoist/linkedout/page/login/SignUpPage.kt
+++ b/app/src/main/java/com/echoist/linkedout/page/login/SignUpPage.kt
@@ -49,6 +49,7 @@ import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.rememberStandardBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
@@ -74,6 +75,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
 import com.echoist.linkedout.R
+import com.echoist.linkedout.Routes
 import com.echoist.linkedout.isEmailValid
 import com.echoist.linkedout.ui.theme.LinkedInColor
 import com.echoist.linkedout.viewModels.SignUpViewModel
@@ -98,6 +100,16 @@ fun SignUpPage(
     val scaffoldState = androidx.compose.material3.rememberBottomSheetScaffoldState(
         bottomSheetState = bottomSheetState
     )
+
+    val navigateToComplete by viewModel.navigateToComplete.collectAsState()
+
+    LaunchedEffect(navigateToComplete) {
+        if (navigateToComplete) {
+            navController.navigate(Routes.SignUpComplete)
+            viewModel.onNavigated()
+        }
+    }
+
     LaunchedEffect(key1 = viewModel.isSignUpApiFinished) {
         //이메일 인증 클릭 성공시 모달 올라오게.
         if (viewModel.isSignUpApiFinished) {
@@ -126,12 +138,12 @@ fun SignUpPage(
         sheetContent = {
             Box {
                 Authentication_6_BottomModal(
-                    { viewModel.getUserEmailCheck(viewModel.userEmail, navController) }, //재요청 인증
+                    { viewModel.getUserEmailCheck(viewModel.userEmail) }, //재요청 인증
                     isError = viewModel.errorCode >= 400,
                     isTypedLastNumber = { list ->
                         keyboardController?.hide()
                         Log.d("6자리 코드 ", list.joinToString(""))
-                        viewModel.requestRegister(list.joinToString(""), navController)
+                        viewModel.requestRegister(list.joinToString(""))
 
                     }, scaffoldState
                 )
@@ -213,12 +225,11 @@ fun SignUpPage(
                                 .padding(start = 20.dp, end = 20.dp, top = 50.dp),
                             onClick = {
                                 keyboardController?.hide()
-                                viewModel.getUserEmailCheck(viewModel.userEmail, navController)
+                                viewModel.getUserEmailCheck(viewModel.userEmail)
                             }
                         ) {
                             Text(text = "인증 메일 보내기", color = Color.Black)
                         }
-
                     }
                 }
 
@@ -253,7 +264,6 @@ fun SignUpPage(
                                 "이메일 주소로 인증 메일이 발송됐습니다.",
                                 "링크를 클릭해 회원가입을 완료해주세요 !!"
                             )
-
                         }
                     }
                 }

--- a/app/src/main/java/com/echoist/linkedout/page/settings/AccountPage.kt
+++ b/app/src/main/java/com/echoist/linkedout/page/settings/AccountPage.kt
@@ -134,7 +134,6 @@ fun AccountPage(navController: NavController, viewModel: SettingsViewModel = hil
                         .background(Color.Black.copy(0.7f)),
                     contentAlignment = Alignment.BottomCenter
                 ) {
-
                     LogoutBox(
                         isCancelClicked = { isLogoutClicked = false },
                         isLogoutClicked = {
@@ -142,18 +141,16 @@ fun AccountPage(navController: NavController, viewModel: SettingsViewModel = hil
                             //로컬 자동로그인, id pw 값 초기화
                             SharedPreferencesUtil.saveClickedAutoLogin(context, false)
 
-                            navController.popBackStack(
-                                "LoginPage",
-                                true
-                            ) //home 까지 삭제 inclusive - 포함
-                            navController.navigate("LoginPage")
+                            navController.navigate(Routes.LoginPage) {
+                                popUpTo(navController.graph.startDestinationId) {
+                                    inclusive = true
+                                }
+                            }
                         }
                     )
                 }
             }
         }
-
-
     )
 }
 

--- a/app/src/main/java/com/echoist/linkedout/page/settings/AccountPage.kt
+++ b/app/src/main/java/com/echoist/linkedout/page/settings/AccountPage.kt
@@ -142,7 +142,7 @@ fun AccountPage(navController: NavController, viewModel: SettingsViewModel = hil
                             SharedPreferencesUtil.saveClickedAutoLogin(context, false)
 
                             navController.navigate(Routes.LoginPage) {
-                                popUpTo(navController.graph.startDestinationId) {
+                                popUpTo(Routes.LoginPage) {
                                     inclusive = true
                                 }
                             }

--- a/app/src/main/java/com/echoist/linkedout/page/settings/ChangeEmailPage.kt
+++ b/app/src/main/java/com/echoist/linkedout/page/settings/ChangeEmailPage.kt
@@ -70,7 +70,6 @@ fun ChangeEmailPage(
     navController: NavController,
     changeEmailViewModel: ChangeEmailViewModel = hiltViewModel()
 ) {
-
     val configuration = LocalConfiguration.current
     val screenHeightDp = configuration.screenHeightDp // 화면의 높이를 DP 단위로 가져옴
 
@@ -111,7 +110,6 @@ fun ChangeEmailPage(
         }
     }
 
-
     BottomSheetScaffold(
         sheetContainerColor = Color(0xFF191919),
         scaffoldState = scaffoldState,
@@ -123,6 +121,7 @@ fun ChangeEmailPage(
                     }, //재요청 인증
                     isError = false,
                     isTypedLastNumber = { list -> //6자리 리스트
+                        changeEmailViewModel.postAuthChangeEmail(list.joinToString(""))
                         //todo 마지막 넘버 입력시 인증 함수 필요 및 isError지정
                         keyboardController?.hide()
                     }, scaffoldState
@@ -136,13 +135,10 @@ fun ChangeEmailPage(
                     }
                 }
             }
-
-
         },
         sheetPeekHeight = (0.8 * screenHeightDp).dp
     ) {
         Scaffold(
-
             topBar = {
                 SettingTopAppBar("이메일 주소 변경", navController)
             },
@@ -164,12 +160,8 @@ fun ChangeEmailPage(
                     )
                     Spacer(modifier = Modifier.height(32.dp))
 
-
                     Text(text = "새 이메일 주소", fontSize = 18.sp, fontWeight = FontWeight.SemiBold)
                     Spacer(modifier = Modifier.height(10.dp))
-
-
-
 
                     CustomOutlinedTextField(
                         email,
@@ -249,7 +241,6 @@ fun ChangeEmailPage(
                             SendEmailFinishedAlert("새 이메일 주소로 인증메일이 발송됐습니다.") {
                                 changeEmailViewModel.isSendEmailVerifyApiFinished = false
                             }
-
                         }
                     }
                 }
@@ -261,8 +252,6 @@ fun ChangeEmailPage(
                         CircularProgressIndicator(color = LinkedInColor)
                     }
                 }
-
-
             }
         )
     }
@@ -294,7 +283,6 @@ fun CustomOutlinedTextField(
             focusedContainerColor = Color(0xFF111111),
             errorBorderColor = Color.Red,
             errorTextColor = Color(0xFF5D5D5D)
-
         ),
         trailingIcon = {
             if (text.isNotEmpty())
@@ -305,7 +293,6 @@ fun CustomOutlinedTextField(
                         onTextChange("")
                     }
                 )
-
         })
 }
 
@@ -327,7 +314,6 @@ fun SendEmailFinishedAlert(text: String, isClicked: () -> Unit) {
             Column {
                 Text(text = text, fontSize = 14.sp)
                 Text(text = "링크를 클릭해 인증을 완료해주세요.", color = LinkedInColor, fontSize = 14.sp)
-
             }
         }
         Box(
@@ -341,8 +327,5 @@ fun SendEmailFinishedAlert(text: String, isClicked: () -> Unit) {
                 contentDescription = "close",
                 modifier = Modifier.clickable { isClicked() })
         }
-
-
     }
 }
-

--- a/app/src/main/java/com/echoist/linkedout/page/settings/ChangeEmailPage.kt
+++ b/app/src/main/java/com/echoist/linkedout/page/settings/ChangeEmailPage.kt
@@ -57,14 +57,19 @@ import androidx.navigation.NavController
 import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
 import com.bumptech.glide.integration.compose.GlideImage
 import com.echoist.linkedout.R
+import com.echoist.linkedout.isEmailValid
 import com.echoist.linkedout.page.login.Authentication_6_BottomModal
 import com.echoist.linkedout.ui.theme.LinkedInColor
+import com.echoist.linkedout.viewModels.ChangeEmailViewModel
 import com.echoist.linkedout.viewModels.SignUpViewModel
 import kotlinx.coroutines.delay
 
 @OptIn(ExperimentalGlideComposeApi::class, ExperimentalMaterial3Api::class)
 @Composable
-fun ChangeEmailPage(navController: NavController) {
+fun ChangeEmailPage(
+    navController: NavController,
+    changeEmailViewModel: ChangeEmailViewModel = hiltViewModel()
+) {
 
     val configuration = LocalConfiguration.current
     val screenHeightDp = configuration.screenHeightDp // 화면의 높이를 DP 단위로 가져옴
@@ -120,7 +125,7 @@ fun ChangeEmailPage(navController: NavController) {
                     isTypedLastNumber = { list -> //6자리 리스트
                         //todo 마지막 넘버 입력시 인증 함수 필요 및 isError지정
                         keyboardController?.hide()
-                    },scaffoldState
+                    }, scaffoldState
                 )
                 if (viewModel.isLoading) {
                     Box(
@@ -153,7 +158,7 @@ fun ChangeEmailPage(navController: NavController) {
                     Spacer(modifier = Modifier.height(10.dp))
 
                     Text(
-                        text = viewModel.getMyInfo().email ?: "noEmail",
+                        text = changeEmailViewModel.getMyInfo().email ?: "noEmail",
                         fontSize = 16.sp,
                         color = Color(0xFF5D5D5D)
                     )
@@ -170,7 +175,7 @@ fun ChangeEmailPage(navController: NavController) {
                         email,
                         { newText ->
                             email = newText
-                            isError = !viewModel.isEmailValid(email)
+                            isError = !email.isEmailValid()
                         },
                         isError = isError,
                         hint = "이메일"

--- a/app/src/main/java/com/echoist/linkedout/page/settings/ChangeEmailPage.kt
+++ b/app/src/main/java/com/echoist/linkedout/page/settings/ChangeEmailPage.kt
@@ -103,11 +103,11 @@ fun ChangeEmailPage(
     val scrollState = rememberScrollState()
 
     //이메일 보냄 api 가 끝나면 2초 후 사라지게
-    LaunchedEffect(key1 = viewModel.isSendEmailVerifyApiFinished) {
-        if (viewModel.isSendEmailVerifyApiFinished) {
+    LaunchedEffect(key1 = changeEmailViewModel.isSendEmailVerifyApiFinished) {
+        if (changeEmailViewModel.isSendEmailVerifyApiFinished) {
             bottomSheetState.show()
             delay(3000)
-            viewModel.isSendEmailVerifyApiFinished = false
+            changeEmailViewModel.isSendEmailVerifyApiFinished = false
         }
     }
 
@@ -119,7 +119,7 @@ fun ChangeEmailPage(
             Box {
                 Authentication_6_BottomModal(
                     reAuthentication = {
-                        viewModel.sendEmailVerificationForChange(email)
+                        changeEmailViewModel.sendEmailVerificationForChange(email)
                     }, //재요청 인증
                     isError = false,
                     isTypedLastNumber = { list -> //6자리 리스트
@@ -203,7 +203,7 @@ fun ChangeEmailPage(
 
                     val enabled = !(isError || email.isEmpty())
                     Button(
-                        onClick = { viewModel.sendEmailVerificationForChange(email) },
+                        onClick = { changeEmailViewModel.sendEmailVerificationForChange(email) },
                         enabled = enabled,
                         shape = RoundedCornerShape(20),
                         modifier = Modifier
@@ -221,7 +221,7 @@ fun ChangeEmailPage(
 
                 }
                 AnimatedVisibility(
-                    visible = viewModel.isSendEmailVerifyApiFinished,
+                    visible = changeEmailViewModel.isSendEmailVerifyApiFinished,
                     enter = fadeIn(
                         animationSpec = tween(
                             durationMillis = 500,
@@ -247,7 +247,7 @@ fun ChangeEmailPage(
                             contentAlignment = Alignment.BottomCenter
                         ) {
                             SendEmailFinishedAlert("새 이메일 주소로 인증메일이 발송됐습니다.") {
-                                viewModel.isSendEmailVerifyApiFinished = false
+                                changeEmailViewModel.isSendEmailVerifyApiFinished = false
                             }
 
                         }

--- a/app/src/main/java/com/echoist/linkedout/page/settings/ChangeEmailPage.kt
+++ b/app/src/main/java/com/echoist/linkedout/page/settings/ChangeEmailPage.kt
@@ -43,6 +43,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
@@ -179,7 +180,8 @@ fun ChangeEmailPage(
                             isError = !email.isEmailValid()
                         },
                         isError = isError,
-                        hint = "이메일"
+                        hint = "이메일",
+                        singLine = true
                     )
                     if (isError) {
                         Text(
@@ -273,6 +275,7 @@ fun CustomOutlinedTextField(
     hint: String,
     isError: Boolean,
     modifier: Modifier = Modifier,
+    singLine: Boolean = false
 ) {
     OutlinedTextField(
         shape = RoundedCornerShape(10),
@@ -293,6 +296,7 @@ fun CustomOutlinedTextField(
             errorBorderColor = Color.Red,
             errorTextColor = Color(0xFF5D5D5D)
         ),
+        singleLine = singLine,
         trailingIcon = {
             if (text.isNotEmpty())
                 Icon(

--- a/app/src/main/java/com/echoist/linkedout/page/settings/ChangePwPage.kt
+++ b/app/src/main/java/com/echoist/linkedout/page/settings/ChangePwPage.kt
@@ -16,6 +16,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -28,117 +29,126 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import com.echoist.linkedout.ui.theme.LinkedInColor
+import com.echoist.linkedout.viewModels.SettingsViewModel
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ChangePwPage(navController: NavController) {
+fun ChangePwPage(navController: NavController, viewModel: SettingsViewModel = hiltViewModel()) {
 
     val scrollState = rememberScrollState()
-        Scaffold(
-            topBar = {
-                SettingTopAppBar("비밀번호 변경", navController)
-            },
-            content = {
-                Column(
-                    Modifier
-                        .verticalScroll(scrollState)
-                        .padding(it)
-                        .padding(horizontal = 20.dp)
-                ) {
-                    Spacer(modifier = Modifier.height(42.dp))
-                    Text(text = "현재 비밀번호", fontSize = 18.sp, fontWeight = FontWeight.SemiBold)
-                    Spacer(modifier = Modifier.height(10.dp))
+    LaunchedEffect(true) {
+        viewModel.getMyInfo()
+    }
+    Scaffold(
+        topBar = {
+            SettingTopAppBar("비밀번호 변경", navController)
+        },
+        content = {
+            Column(
+                Modifier
+                    .verticalScroll(scrollState)
+                    .padding(it)
+                    .padding(horizontal = 20.dp)
+            ) {
+                Spacer(modifier = Modifier.height(42.dp))
+                Text(text = "현재 비밀번호", fontSize = 18.sp, fontWeight = FontWeight.SemiBold)
+                Spacer(modifier = Modifier.height(10.dp))
 
-                    var oldPw by remember { mutableStateOf("") }
-                    var oldPwErr by remember { mutableStateOf(false) } //todo 에러처리 할 구문 생각해야할것.
+                var oldPw by remember { mutableStateOf("") }
+                var oldPwErr by remember { mutableStateOf(false) } //todo 에러처리 할 구문 생각해야할것.
 
-                    CustomOutlinedTextField(
-                        oldPw,
-                        { newText ->
-                            oldPw = newText
-                        },
-                        isError = oldPwErr,
-                        hint = "비밀번호"
+                CustomOutlinedTextField(
+                    oldPw,
+                    { newText ->
+                        oldPw = newText
+                    },
+                    isError = oldPwErr,
+                    hint = "비밀번호",
+                    singLine = true
+                )
+                if (oldPwErr) {
+                    Text(text = "올바른 이메일 형식이 아닙니다.", color = Color.Red, fontSize = 12.sp)
+                }
+                Spacer(modifier = Modifier.height(12.dp))
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(text = "비밀번호를 잊으셨나요? ", fontSize = 12.sp, color = Color(0xFF5D5D5D))
+                    Text(
+                        text = "비밀번호 재설정",
+                        fontSize = 12.sp,
+                        color = LinkedInColor,
+                        modifier = Modifier.clickable { navController.navigate("ResetPwPageWithEmail") },
+                        style = TextStyle(textDecoration = TextDecoration.Underline)
                     )
-                    if (oldPwErr) {
-                        Text(text = "올바른 이메일 형식이 아닙니다.", color = Color.Red, fontSize = 12.sp)
-                    }
-                    Spacer(modifier = Modifier.height(12.dp))
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        Text(text = "비밀번호를 잊으셨나요? ", fontSize = 12.sp, color = Color(0xFF5D5D5D))
-                        Text(
-                            text = "비밀번호 재설정",
-                            fontSize = 12.sp,
-                            color = LinkedInColor,
-                            modifier = Modifier.clickable { navController.navigate("ResetPwPageWithEmail") },
-                            style = TextStyle(textDecoration = TextDecoration.Underline)
-                        )
-                    }
-                    Spacer(modifier = Modifier.height(32.dp))
+                }
+                Spacer(modifier = Modifier.height(32.dp))
 
+                Text(text = "새 비밀번호", fontSize = 18.sp, fontWeight = FontWeight.SemiBold)
+                Spacer(modifier = Modifier.height(10.dp))
 
-                    Text(text = "새 비밀번호", fontSize = 18.sp, fontWeight = FontWeight.SemiBold)
-                    Spacer(modifier = Modifier.height(10.dp))
+                var newPw by remember { mutableStateOf("") } //todo 이 값들을 페이지 나갔다 들어와도 유지되게끔 할것인지.
+                var newPwErr by remember { mutableStateOf(false) } //todo 에러처리 할 구문 생각해야할것.
 
-
-                    var newPw by remember { mutableStateOf("") } //todo 이 값들을 페이지 나갔다 들어와도 유지되게끔 할것인지.
-                    var newPwErr by remember { mutableStateOf(false) } //todo 에러처리 할 구문 생각해야할것.
-
-                    CustomOutlinedTextField(
-                        newPw,
-                        { newText ->
-                            newPw = newText
-                        },
-                        isError = newPwErr,
-                        hint = "새 비밀번호"
-                    )
-                    if (newPwErr) {
-                        Text(text = "올바른 이메일 형식이 아닙니다.", color = Color.Red, fontSize = 12.sp)
-                    }
-
-                    Spacer(modifier = Modifier.height(32.dp))
-
-                    Text(text = "새 비밀번호 확인", fontSize = 18.sp, fontWeight = FontWeight.SemiBold)
-                    Spacer(modifier = Modifier.height(10.dp))
-
-                    var newPwCheck by remember { mutableStateOf("") }
-                    var newPwCheckErr by remember { mutableStateOf(false) } //todo 에러처리 할 구문 생각해야할것.
-
-                    CustomOutlinedTextField(
-                        newPwCheck, //이메일 체크 에러
-                        { newText ->
-                            newPwCheck = newText
-                            if (newPw != newPwCheck) newPwCheckErr = true
-                        },
-                        isError = newPwCheckErr,
-                        hint = "새 비밀번호 확인"
-                    )
-                    if (newPwCheckErr) {
-                        Text(text = "비밀번호가 일치하지 않습니다.", color = Color.Red, fontSize = 12.sp)
-                    }
-
-                    Spacer(modifier = Modifier.height(187.dp))
-
-                    val enabled = newPw == newPwCheck && newPw.isNotBlank() //문자가 있어야함
-                    Button(
-                        onClick = { /* todo 비밀번호 변경 기능구현 */ },
-                        enabled = enabled,
-                        shape = RoundedCornerShape(20),
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .height(61.dp),
-                        colors = ButtonDefaults.buttonColors(
-                            containerColor = LinkedInColor,
-                            disabledContainerColor = Color(0xFF868686),
-
-                            )
-                    ) {
-                        Text(text = "변경하기", color = Color.Black)
-                    }
+                CustomOutlinedTextField(
+                    newPw,
+                    { newText ->
+                        newPw = newText
+                    },
+                    isError = newPwErr,
+                    hint = "새 비밀번호",
+                    singLine = true
+                )
+                if (newPwErr) {
+                    Text(text = "올바른 이메일 형식이 아닙니다.", color = Color.Red, fontSize = 12.sp)
                 }
 
+                Spacer(modifier = Modifier.height(32.dp))
+
+                Text(text = "새 비밀번호 확인", fontSize = 18.sp, fontWeight = FontWeight.SemiBold)
+                Spacer(modifier = Modifier.height(10.dp))
+
+                var newPwCheck by remember { mutableStateOf("") }
+                var newPwCheckErr by remember { mutableStateOf(false) } //todo 에러처리 할 구문 생각해야할것.
+
+                CustomOutlinedTextField(
+                    newPwCheck, //이메일 체크 에러
+                    { newText ->
+                        newPwCheck = newText
+                        if (newPw != newPwCheck) newPwCheckErr = true
+                    },
+                    isError = newPwCheckErr,
+                    hint = "새 비밀번호 확인",
+                    singLine = true
+                )
+                if (newPwCheckErr) {
+                    Text(text = "비밀번호가 일치하지 않습니다.", color = Color.Red, fontSize = 12.sp)
+                }
+
+                Spacer(modifier = Modifier.height(187.dp))
+
+                val enabled = newPw == newPwCheck && newPw.isNotBlank() //문자가 있어야함
+                Button(
+                    onClick = {
+                        viewModel.updateMyInfo(
+                            viewModel.newProfile.copy(password = newPw),
+                            navController
+                        )
+                    },
+                    enabled = enabled,
+                    shape = RoundedCornerShape(20),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(61.dp),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = LinkedInColor,
+                        disabledContainerColor = Color(0xFF868686),
+
+                        )
+                ) {
+                    Text(text = "변경하기", color = Color.Black)
+                }
             }
-        )
-    }
+        }
+    )
+}

--- a/app/src/main/java/com/echoist/linkedout/page/settings/MyPage.kt
+++ b/app/src/main/java/com/echoist/linkedout/page/settings/MyPage.kt
@@ -139,7 +139,6 @@ fun MyPage(
         bottomSheetState = bottomSheetState
     )
 
-
     BottomSheetScaffold(
         sheetContainerColor = Color(0xFF111111),
         scaffoldState = scaffoldState,
@@ -172,8 +171,6 @@ fun MyPage(
                     }, viewModel
                 )
             }
-
-
         },
         sheetPeekHeight = 0.dp
     ) {
@@ -197,8 +194,7 @@ fun MyPage(
                         .verticalScroll(scrollState)
 
                 ) {
-                    MySettings(item = viewModel.getMyInfo()) {
-                        Log.d(TAG, "MyPage: ${viewModel.getMyInfo()}")
+                    MySettings(viewModel.getMyInfo()) {
                         scope.launch {
                             bottomSheetState.expand()
                         }
@@ -237,7 +233,6 @@ fun MyPage(
 @OptIn(ExperimentalGlideComposeApi::class)
 @Composable
 fun MySettings(item: UserInfo, onClick: () -> Unit) {
-
     val annotatedString = remember {
         AnnotatedString.Builder().apply {
             withStyle(
@@ -246,7 +241,7 @@ fun MySettings(item: UserInfo, onClick: () -> Unit) {
                     fontWeight = FontWeight.Bold
                 )
             ) {
-                append("${item.nickname!!} ")
+                append("${item.nickname ?: ""} ")
             }
             append("아무개")
         }.toAnnotatedString()

--- a/app/src/main/java/com/echoist/linkedout/page/settings/MyPage.kt
+++ b/app/src/main/java/com/echoist/linkedout/page/settings/MyPage.kt
@@ -115,11 +115,9 @@ import kotlinx.coroutines.launch
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MyPage(
-    navController: NavController
+    navController: NavController,
+    viewModel: SettingsViewModel = hiltViewModel()
 ) {
-
-
-    val viewModel: SettingsViewModel = hiltViewModel()
 
     var isApiFinished by remember {
         mutableStateOf(false)

--- a/app/src/main/java/com/echoist/linkedout/page/settings/ResetPwPage.kt
+++ b/app/src/main/java/com/echoist/linkedout/page/settings/ResetPwPage.kt
@@ -26,16 +26,15 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import com.echoist.linkedout.ui.theme.LinkedInColor
-import com.echoist.linkedout.viewModels.SignUpViewModel
+import com.echoist.linkedout.viewModels.ResetPwViewModel
 
 @Composable
-fun ResetPwPage(navController: NavController, token: String = "empty_token") {
+fun ResetPwPage(
+    navController: NavController, token: String = "empty_token",
+    viewModel: ResetPwViewModel = hiltViewModel()
+) {
 
     val scrollState = rememberScrollState()
-    val viewModel: SignUpViewModel = hiltViewModel()
-
-
-
 
     Scaffold(
         topBar = {
@@ -91,10 +90,8 @@ fun ResetPwPage(navController: NavController, token: String = "empty_token") {
                     Text(text = "비밀번호가 불일치합니다.", color = Color.Red, fontSize = 12.sp)
                 }
 
-
                 Spacer(modifier = Modifier.height(187.dp))
                 val focusManager = LocalFocusManager.current
-
 
                 val enabled = newPw == newPwCheck && newPw.isNotBlank() //문자가 있어야함
                 Button(
@@ -110,14 +107,11 @@ fun ResetPwPage(navController: NavController, token: String = "empty_token") {
                     colors = ButtonDefaults.buttonColors(
                         containerColor = LinkedInColor,
                         disabledContainerColor = Color(0xFF868686),
-
-                        )
+                    )
                 ) {
                     Text(text = "변경하기", color = Color.Black)
                 }
             }
-
-
         }
     )
 }

--- a/app/src/main/java/com/echoist/linkedout/page/settings/ResetPwPageWithEmail.kt
+++ b/app/src/main/java/com/echoist/linkedout/page/settings/ResetPwPageWithEmail.kt
@@ -149,7 +149,8 @@ fun ResetPwPageWithEmail(
                         },
 
                         isError = isError,
-                        hint = "이메일"
+                        hint = "이메일",
+                        singLine = true
                     )
                     if (isError) {
                         Text(
@@ -162,7 +163,6 @@ fun ResetPwPageWithEmail(
 
                     val enabled = !(isError || email.isEmpty())
                     val focusManager = LocalFocusManager.current
-
 
                     Button(
                         //비번 변경 이메일요청

--- a/app/src/main/java/com/echoist/linkedout/page/settings/ResetPwPageWithEmail.kt
+++ b/app/src/main/java/com/echoist/linkedout/page/settings/ResetPwPageWithEmail.kt
@@ -49,15 +49,19 @@ import androidx.navigation.NavController
 import com.echoist.linkedout.isEmailValid
 import com.echoist.linkedout.page.login.Authentication_6_BottomModal
 import com.echoist.linkedout.ui.theme.LinkedInColor
+import com.echoist.linkedout.viewModels.ChangeEmailViewModel
+import com.echoist.linkedout.viewModels.ResetPwViewModel
 import com.echoist.linkedout.viewModels.SignUpViewModel
 import kotlinx.coroutines.delay
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ResetPwPageWithEmail(navController: NavController) {
+fun ResetPwPageWithEmail(
+    navController: NavController,
+    viewModel: ResetPwViewModel = hiltViewModel()
+) {
 
     val scrollState = rememberScrollState()
-    val viewModel: SignUpViewModel = hiltViewModel()
 
     val passwordFocusRequester = remember { FocusRequester() }
 
@@ -81,7 +85,6 @@ fun ResetPwPageWithEmail(navController: NavController) {
             viewModel.isSendEmailVerifyApiFinished = false
         }
     }
-
 
     BottomSheetScaffold(
         sheetContainerColor = Color(0xFF191919),
@@ -107,8 +110,6 @@ fun ResetPwPageWithEmail(navController: NavController) {
                     }
                 }
             }
-
-
         },
         sheetPeekHeight = (0.8 * screenHeightDp).dp
     ) {
@@ -212,11 +213,9 @@ fun ResetPwPageWithEmail(navController: NavController) {
                             SendEmailFinishedAlert("이메일 주소로 인증메일이 발송됐습니다.") {
                                 viewModel.isSendEmailVerifyApiFinished = false
                             }
-
                         }
                     }
                 }
-
             }
         )
     }

--- a/app/src/main/java/com/echoist/linkedout/page/settings/ResetPwPageWithEmail.kt
+++ b/app/src/main/java/com/echoist/linkedout/page/settings/ResetPwPageWithEmail.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
+import com.echoist.linkedout.isEmailValid
 import com.echoist.linkedout.page.login.Authentication_6_BottomModal
 import com.echoist.linkedout.ui.theme.LinkedInColor
 import com.echoist.linkedout.viewModels.SignUpViewModel
@@ -87,14 +88,15 @@ fun ResetPwPageWithEmail(navController: NavController) {
         scaffoldState = scaffoldState,
         sheetContent = {
             Box {
-                Authentication_6_BottomModal(reAuthentication =
-                {
-                    viewModel.requestChangePw(email)
-                }, //재요청 인증
+                Authentication_6_BottomModal(
+                    reAuthentication =
+                    {
+                        viewModel.requestChangePw(email)
+                    }, //재요청 인증
                     isError = false,
                     isTypedLastNumber = {
                         keyboardController?.hide()
-                    },scaffoldState
+                    }, scaffoldState
                 )
                 if (viewModel.isLoading) {
                     Box(
@@ -142,7 +144,7 @@ fun ResetPwPageWithEmail(navController: NavController) {
                         email,
                         { newText ->
                             email = newText
-                            isError = !viewModel.isEmailValid(email)
+                            isError = !email.isEmailValid()
                         },
 
                         isError = isError,

--- a/app/src/main/java/com/echoist/linkedout/presentation/TabletChangeEmailScreen.kt
+++ b/app/src/main/java/com/echoist/linkedout/presentation/TabletChangeEmailScreen.kt
@@ -48,10 +48,12 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
 import com.bumptech.glide.integration.compose.GlideImage
 import com.echoist.linkedout.R
+import com.echoist.linkedout.isEmailValid
 import com.echoist.linkedout.page.login.Authentication_6_BottomModal
 import com.echoist.linkedout.page.settings.CustomOutlinedTextField
 import com.echoist.linkedout.page.settings.SendEmailFinishedAlert
 import com.echoist.linkedout.ui.theme.LinkedInColor
+import com.echoist.linkedout.viewModels.ChangeEmailViewModel
 import com.echoist.linkedout.viewModels.SignUpViewModel
 import kotlinx.coroutines.delay
 
@@ -59,6 +61,7 @@ import kotlinx.coroutines.delay
 @Composable
 fun TabletChangeEmailScreen(
     viewModel: SignUpViewModel = hiltViewModel(),
+    changeEmailViewModel: ChangeEmailViewModel = hiltViewModel(),
     contentPadding: PaddingValues
 ) {
     val configuration = LocalConfiguration.current
@@ -139,7 +142,7 @@ fun TabletChangeEmailScreen(
                 Spacer(modifier = Modifier.height(10.dp))
 
                 Text(
-                    text = viewModel.getMyInfo().email ?: "noEmail",
+                    text = changeEmailViewModel.getMyInfo().email ?: "noEmail",
                     fontSize = 16.sp,
                     color = Color(0xFF5D5D5D)
                 )
@@ -152,7 +155,7 @@ fun TabletChangeEmailScreen(
                     email,
                     { newText ->
                         email = newText
-                        isError = !viewModel.isEmailValid(email)
+                        isError = !email.isEmailValid()
                     },
                     isError = isError,
                     hint = "이메일"

--- a/app/src/main/java/com/echoist/linkedout/presentation/TabletChangeEmailScreen.kt
+++ b/app/src/main/java/com/echoist/linkedout/presentation/TabletChangeEmailScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.rememberStandardBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -36,10 +37,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
@@ -48,6 +51,8 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
 import com.bumptech.glide.integration.compose.GlideImage
 import com.echoist.linkedout.R
+import com.echoist.linkedout.Routes
+import com.echoist.linkedout.SharedPreferencesUtil
 import com.echoist.linkedout.isEmailValid
 import com.echoist.linkedout.page.login.Authentication_6_BottomModal
 import com.echoist.linkedout.page.settings.CustomOutlinedTextField
@@ -60,9 +65,9 @@ import kotlinx.coroutines.delay
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalGlideComposeApi::class)
 @Composable
 fun TabletChangeEmailScreen(
-    viewModel: SignUpViewModel = hiltViewModel(),
     changeEmailViewModel: ChangeEmailViewModel = hiltViewModel(),
-    contentPadding: PaddingValues
+    contentPadding: PaddingValues,
+    moveToLoginPage: () -> Unit
 ) {
     val configuration = LocalConfiguration.current
     val screenHeightDp = configuration.screenHeightDp // 화면의 높이를 DP 단위로 가져옴
@@ -75,6 +80,7 @@ fun TabletChangeEmailScreen(
     )
     var email by remember { mutableStateOf("") }
     var isError by remember { mutableStateOf(false) }
+    var showToast by remember { mutableStateOf(false) }
 
     val annotatedString = remember {
         AnnotatedString.Builder().apply {
@@ -90,6 +96,20 @@ fun TabletChangeEmailScreen(
             }
             append("을 눌러 해당 이메일로 인증을 완료해 주세요.")
         }.toAnnotatedString()
+    }
+
+    val context = LocalContext.current
+    val navigateToComplete by changeEmailViewModel.navigateToComplete.collectAsState()
+
+    LaunchedEffect(navigateToComplete) {
+        if (navigateToComplete) {
+            bottomSheetState.hide()
+            showToast = true
+            delay(2000)
+            SharedPreferencesUtil.saveClickedAutoLogin(context, false)
+            moveToLoginPage()
+            showToast = false
+        }
     }
 
     //이메일 보냄 api 가 끝나면 2초 후 사라지게
@@ -111,12 +131,12 @@ fun TabletChangeEmailScreen(
                         changeEmailViewModel.sendEmailVerificationForChange(email)
                     }, //재요청 인증
                     isError = false,
-                    isTypedLastNumber = { list -> //6자리 리스트
-                        //todo 마지막 넘버 입력시 인증 함수 필요 및 isError지정
+                    isTypedLastNumber = { list ->
+                        changeEmailViewModel.postAuthChangeEmail(list.joinToString(""))
                         keyboardController?.hide()
                     }, scaffoldState
                 )
-                if (viewModel.isLoading) {
+                if (changeEmailViewModel.isLoading) {
                     Box(
                         modifier = Modifier.fillMaxSize(),
                         contentAlignment = Alignment.Center
@@ -158,7 +178,8 @@ fun TabletChangeEmailScreen(
                         isError = !email.isEmailValid()
                     },
                     isError = isError,
-                    hint = "이메일"
+                    hint = "이메일",
+                    singLine = true
                 )
                 if (isError) {
                     Text(
@@ -231,7 +252,48 @@ fun TabletChangeEmailScreen(
                     }
                 }
             }
-            if (viewModel.isLoading) {
+            AnimatedVisibility(
+                visible = navigateToComplete,
+                enter = fadeIn(
+                    animationSpec = tween(
+                        durationMillis = 500,
+                        easing = FastOutSlowInEasing
+                    )
+                ),
+                exit = fadeOut(
+                    animationSpec = tween(
+                        durationMillis = 500,
+                        easing = LinearEasing
+                    )
+                )
+            ) {
+                Box(modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color.Black.copy(0.7f))
+                    .clickable(enabled = false) { }) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .align(Alignment.Center)
+                            .height(60.dp)
+                            .padding(horizontal = 20.dp)
+                            .background(
+                                Color(0xFF616FED),
+                                shape = RoundedCornerShape(10)
+                            )
+                    ) {
+                        Text(
+                            text = "이메일 주소가 변경되었습니다. \n 다시 로그인해주세요.",
+                            color = Color.White,
+                            modifier = Modifier
+                                .padding(horizontal = 20.dp)
+                                .align(Alignment.Center),
+                            textAlign = TextAlign.Center
+                        )
+                    }
+                }
+            }
+            if (changeEmailViewModel.isLoading) {
                 Box(
                     modifier = Modifier.fillMaxSize(),
                     contentAlignment = Alignment.Center

--- a/app/src/main/java/com/echoist/linkedout/presentation/TabletChangeEmailScreen.kt
+++ b/app/src/main/java/com/echoist/linkedout/presentation/TabletChangeEmailScreen.kt
@@ -93,11 +93,11 @@ fun TabletChangeEmailScreen(
     }
 
     //이메일 보냄 api 가 끝나면 2초 후 사라지게
-    LaunchedEffect(key1 = viewModel.isSendEmailVerifyApiFinished) {
-        if (viewModel.isSendEmailVerifyApiFinished) {
+    LaunchedEffect(key1 = changeEmailViewModel.isSendEmailVerifyApiFinished) {
+        if (changeEmailViewModel.isSendEmailVerifyApiFinished) {
             bottomSheetState.show()
             delay(3000)
-            viewModel.isSendEmailVerifyApiFinished = false
+            changeEmailViewModel.isSendEmailVerifyApiFinished = false
         }
     }
 
@@ -108,7 +108,7 @@ fun TabletChangeEmailScreen(
             Box {
                 Authentication_6_BottomModal(
                     reAuthentication = {
-                        viewModel.sendEmailVerificationForChange(email)
+                        changeEmailViewModel.sendEmailVerificationForChange(email)
                     }, //재요청 인증
                     isError = false,
                     isTypedLastNumber = { list -> //6자리 리스트
@@ -183,7 +183,7 @@ fun TabletChangeEmailScreen(
 
                 val enabled = !(isError || email.isEmpty())
                 Button(
-                    onClick = { viewModel.sendEmailVerificationForChange(email) },
+                    onClick = { changeEmailViewModel.sendEmailVerificationForChange(email) },
                     enabled = enabled,
                     shape = RoundedCornerShape(20),
                     modifier = Modifier
@@ -199,7 +199,7 @@ fun TabletChangeEmailScreen(
                 }
             }
             AnimatedVisibility(
-                visible = viewModel.isSendEmailVerifyApiFinished,
+                visible = changeEmailViewModel.isSendEmailVerifyApiFinished,
                 enter = fadeIn(
                     animationSpec = tween(
                         durationMillis = 500,
@@ -225,7 +225,7 @@ fun TabletChangeEmailScreen(
                         contentAlignment = Alignment.BottomCenter
                     ) {
                         SendEmailFinishedAlert("새 이메일 주소로 인증메일이 발송됐습니다.") {
-                            viewModel.isSendEmailVerifyApiFinished = false
+                            changeEmailViewModel.isSendEmailVerifyApiFinished = false
                         }
 
                     }

--- a/app/src/main/java/com/echoist/linkedout/presentation/TabletResetPwScreen.kt
+++ b/app/src/main/java/com/echoist/linkedout/presentation/TabletResetPwScreen.kt
@@ -51,13 +51,13 @@ import androidx.navigation.NavHostController
 import com.echoist.linkedout.isEmailValid
 import com.echoist.linkedout.page.settings.SendEmailFinishedAlert
 import com.echoist.linkedout.ui.theme.LinkedInColor
-import com.echoist.linkedout.viewModels.SignUpViewModel
+import com.echoist.linkedout.viewModels.ResetPwViewModel
 import kotlinx.coroutines.delay
 
 @Composable
 fun TabletResetPwRoute(
     navController: NavHostController,
-    viewModel: SignUpViewModel = hiltViewModel()
+    viewModel: ResetPwViewModel = hiltViewModel()
 ) {
     val isSendEmailVerifyApiFinished = viewModel.isSendEmailVerifyApiFinished
     val isLoading = viewModel.isLoading

--- a/app/src/main/java/com/echoist/linkedout/presentation/TabletResetPwScreen.kt
+++ b/app/src/main/java/com/echoist/linkedout/presentation/TabletResetPwScreen.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
+import com.echoist.linkedout.isEmailValid
 import com.echoist.linkedout.page.settings.SendEmailFinishedAlert
 import com.echoist.linkedout.ui.theme.LinkedInColor
 import com.echoist.linkedout.viewModels.SignUpViewModel
@@ -74,7 +75,7 @@ fun TabletResetPwRoute(
         isLoading = isLoading,
         isSendEmailVerifyApiFinished = isSendEmailVerifyApiFinished,
         onEmailSubmit = { email -> viewModel.requestChangePw(email) },
-        isEmailValid = { email -> viewModel.isEmailValid(email) },
+        isEmailValid = { email -> email.isEmailValid() },
         onAlertDismiss = { viewModel.isSendEmailVerifyApiFinished = false },
         onBackPress = { navController.popBackStack() }
     )

--- a/app/src/main/java/com/echoist/linkedout/presentation/TabletSignUpScreen.kt
+++ b/app/src/main/java/com/echoist/linkedout/presentation/TabletSignUpScreen.kt
@@ -97,11 +97,11 @@ fun TabletSignUpRoute(
         onBackPressed = { navController.popBackStack() },
         onSubmitEmail = {
             keyboardController?.hide()
-            viewModel.getUserEmailCheck(viewModel.userEmail, navController)
+            viewModel.getUserEmailCheck(viewModel.userEmail)
         },
         onInputComplete = {
             keyboardController?.hide()
-            viewModel.requestRegister(it, navController)
+            viewModel.requestRegister(it)
         }
     )
 }
@@ -127,7 +127,6 @@ internal fun TabletSignUpScreen(
             SignUpBottomSheetContent(
                 viewModel = viewModel,
                 scaffoldState = scaffoldState,
-                navController = navController,
                 onInputComplete = onInputComplete
             )
         },
@@ -244,12 +243,11 @@ private fun SignUpContent(
 private fun SignUpBottomSheetContent(
     viewModel: SignUpViewModel,
     scaffoldState: BottomSheetScaffoldState,
-    navController: NavController,
     onInputComplete: (String) -> Unit
 ) {
     Box {
         Authentication_6_BottomModal(
-            { viewModel.getUserEmailCheck(viewModel.userEmail, navController) }, //재요청 인증
+            { viewModel.getUserEmailCheck(viewModel.userEmail) }, //재요청 인증
             isError = viewModel.errorCode >= 400,
             isTypedLastNumber = { list ->
                 onInputComplete(list.joinToString(""))

--- a/app/src/main/java/com/echoist/linkedout/viewModels/ChangeEmailViewModel.kt
+++ b/app/src/main/java/com/echoist/linkedout/viewModels/ChangeEmailViewModel.kt
@@ -42,7 +42,7 @@ class ChangeEmailViewModel @Inject constructor(
     }
 
     var isSendEmailVerifyApiFinished by mutableStateOf(false)
-    fun sendEmailVerificationForChange(email: String) { //코루틴스코프에서 순차적으로 수행된다. 뷰모델스코프는 위에걸로
+    fun sendEmailVerificationForChange(email: String) {
         isLoading = true
         viewModelScope.launch {
             try {
@@ -71,7 +71,23 @@ class ChangeEmailViewModel @Inject constructor(
                 isLoading = false
             }
         }
-
     }
 
+    fun postAuthChangeEmail(code: String){
+        viewModelScope.launch {
+            try {
+                val userEmail = SignUpApi.ChangeEmail(code)
+                val response = signUpApi.postAuthChangeEmail(userEmail)
+                if(response.isSuccessful){
+                    Log.e("authApiSuccess3", "${response.headers()}")
+                    Log.e("authApiSuccess3", "${response.code()}")
+                } else {
+                    Log.e("authApiFailed3", "Failed : ${response.headers()}")
+                    Log.e("authApiFailed3", "${response.code()}")
+                }
+            } catch (e: Exception) {
+                Log.e("writeEssayApiFailed3", "Failed: ${e.message}")
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/echoist/linkedout/viewModels/ChangeEmailViewModel.kt
+++ b/app/src/main/java/com/echoist/linkedout/viewModels/ChangeEmailViewModel.kt
@@ -13,6 +13,8 @@ import com.echoist.linkedout.data.ExampleItems
 import com.echoist.linkedout.data.UserInfo
 import com.echoist.linkedout.page.myLog.Token
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -73,14 +75,19 @@ class ChangeEmailViewModel @Inject constructor(
         }
     }
 
-    fun postAuthChangeEmail(code: String){
+    private val _navigateToComplete = MutableStateFlow(false)
+    val navigateToComplete: StateFlow<Boolean> = _navigateToComplete
+
+    fun postAuthChangeEmail(code: String) {
         viewModelScope.launch {
             try {
                 val userEmail = SignUpApi.ChangeEmail(code)
                 val response = signUpApi.postAuthChangeEmail(userEmail)
-                if(response.isSuccessful){
+                if (response.isSuccessful) {
                     Log.e("authApiSuccess3", "${response.headers()}")
                     Log.e("authApiSuccess3", "${response.code()}")
+                    readMyInfo()
+                    _navigateToComplete.value = true
                 } else {
                     Log.e("authApiFailed3", "Failed : ${response.headers()}")
                     Log.e("authApiFailed3", "${response.code()}")
@@ -89,5 +96,9 @@ class ChangeEmailViewModel @Inject constructor(
                 Log.e("writeEssayApiFailed3", "Failed: ${e.message}")
             }
         }
+    }
+
+    fun onNavigated() {
+        _navigateToComplete.value = false
     }
 }

--- a/app/src/main/java/com/echoist/linkedout/viewModels/ChangeEmailViewModel.kt
+++ b/app/src/main/java/com/echoist/linkedout/viewModels/ChangeEmailViewModel.kt
@@ -1,17 +1,77 @@
 package com.echoist.linkedout.viewModels
 
+import android.content.ContentValues
+import android.util.Log
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.echoist.linkedout.api.SignUpApi
+import com.echoist.linkedout.api.UserApi
 import com.echoist.linkedout.data.ExampleItems
 import com.echoist.linkedout.data.UserInfo
+import com.echoist.linkedout.page.myLog.Token
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class ChangeEmailViewModel @Inject constructor(
+    private val signUpApi: SignUpApi,
+    private val userApi: UserApi,
     private val exampleItems: ExampleItems
 ) : ViewModel() {
+
+    var isLoading by mutableStateOf(false)
+
+    private suspend fun readMyInfo() {
+        try {
+            val response = userApi.getMyInfo()
+
+            exampleItems.myProfile = response.data.user
+            exampleItems.myProfile.essayStats = response.data.essayStats
+
+        } catch (_: Exception) {
+            Log.d(ContentValues.TAG, "readMyInfo: error err")
+        }
+    }
 
     fun getMyInfo(): UserInfo {
         return exampleItems.myProfile
     }
+
+    var isSendEmailVerifyApiFinished by mutableStateOf(false)
+    fun sendEmailVerificationForChange(email: String) { //코루틴스코프에서 순차적으로 수행된다. 뷰모델스코프는 위에걸로
+        isLoading = true
+        viewModelScope.launch {
+            try {
+                val userEmail = SignUpApi.EmailRequest(email)
+                val response = signUpApi.sendEmailVerificationForChange(userEmail)
+
+                if (response.isSuccessful) {
+                    Log.e("authApiSuccess2", "${response.headers()}")
+                    Log.e("authApiSuccess2", "${response.code()}")
+
+                    Token.accessToken =
+                        response.headers()["x-access-token"]?.takeIf { it.isNotEmpty() }
+                            ?: Token.accessToken
+                    readMyInfo()
+                    isSendEmailVerifyApiFinished = true
+
+                } else {
+                    Log.e("authApiFailed2", "Failed : ${response.headers()}")
+                    Log.e("authApiFailed2", "${response.code()}")
+                }
+
+            } catch (e: Exception) {
+                // api 요청 실패
+                Log.e("writeEssayApiFailed2", "Failed: ${e.message}")
+            } finally {
+                isLoading = false
+            }
+        }
+
+    }
+
 }

--- a/app/src/main/java/com/echoist/linkedout/viewModels/ChangeEmailViewModel.kt
+++ b/app/src/main/java/com/echoist/linkedout/viewModels/ChangeEmailViewModel.kt
@@ -1,0 +1,17 @@
+package com.echoist.linkedout.viewModels
+
+import androidx.lifecycle.ViewModel
+import com.echoist.linkedout.data.ExampleItems
+import com.echoist.linkedout.data.UserInfo
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class ChangeEmailViewModel @Inject constructor(
+    private val exampleItems: ExampleItems
+) : ViewModel() {
+
+    fun getMyInfo(): UserInfo {
+        return exampleItems.myProfile
+    }
+}

--- a/app/src/main/java/com/echoist/linkedout/viewModels/ChangeEmailViewModel.kt
+++ b/app/src/main/java/com/echoist/linkedout/viewModels/ChangeEmailViewModel.kt
@@ -27,13 +27,17 @@ class ChangeEmailViewModel @Inject constructor(
 
     var isLoading by mutableStateOf(false)
 
+    var isSendEmailVerifyApiFinished by mutableStateOf(false)
+
+    private val _navigateToComplete = MutableStateFlow(false)
+    val navigateToComplete: StateFlow<Boolean> = _navigateToComplete
+
     private suspend fun readMyInfo() {
         try {
             val response = userApi.getMyInfo()
 
             exampleItems.myProfile = response.data.user
             exampleItems.myProfile.essayStats = response.data.essayStats
-
         } catch (_: Exception) {
             Log.d(ContentValues.TAG, "readMyInfo: error err")
         }
@@ -43,7 +47,6 @@ class ChangeEmailViewModel @Inject constructor(
         return exampleItems.myProfile
     }
 
-    var isSendEmailVerifyApiFinished by mutableStateOf(false)
     fun sendEmailVerificationForChange(email: String) {
         isLoading = true
         viewModelScope.launch {
@@ -60,7 +63,6 @@ class ChangeEmailViewModel @Inject constructor(
                             ?: Token.accessToken
                     readMyInfo()
                     isSendEmailVerifyApiFinished = true
-
                 } else {
                     Log.e("authApiFailed2", "Failed : ${response.headers()}")
                     Log.e("authApiFailed2", "${response.code()}")
@@ -74,9 +76,6 @@ class ChangeEmailViewModel @Inject constructor(
             }
         }
     }
-
-    private val _navigateToComplete = MutableStateFlow(false)
-    val navigateToComplete: StateFlow<Boolean> = _navigateToComplete
 
     fun postAuthChangeEmail(code: String) {
         viewModelScope.launch {
@@ -96,9 +95,5 @@ class ChangeEmailViewModel @Inject constructor(
                 Log.e("writeEssayApiFailed3", "Failed: ${e.message}")
             }
         }
-    }
-
-    fun onNavigated() {
-        _navigateToComplete.value = false
     }
 }

--- a/app/src/main/java/com/echoist/linkedout/viewModels/ResetPwViewModel.kt
+++ b/app/src/main/java/com/echoist/linkedout/viewModels/ResetPwViewModel.kt
@@ -1,0 +1,75 @@
+package com.echoist.linkedout.viewModels
+
+import android.util.Log
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.echoist.linkedout.api.SignUpApi
+import com.echoist.linkedout.page.myLog.Token
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class ResetPwViewModel @Inject constructor(
+    private val signUpApi: SignUpApi
+) : ViewModel() {
+
+    var isLoading by mutableStateOf(false)
+
+    var isSendEmailVerifyApiFinished by mutableStateOf(false)
+
+    fun requestChangePw(email: String) {
+        isLoading = true
+        viewModelScope.launch {
+            isLoading = true
+            val userEmail = SignUpApi.EmailRequest(email)
+            val response = signUpApi.requestChangePw(userEmail)
+
+            if (response.code() == 201) { //성공
+                Log.d("requestChangePw api header", "${response.headers()}")
+                Log.d("requestChangePw api code", "${response.code()}")
+                //헤더에 토큰이 없다.
+                Token.accessToken = response.headers()["x-access-token"]?.takeIf { it.isNotEmpty() }
+                    ?: Token.accessToken
+                isSendEmailVerifyApiFinished = true
+            } else {
+                // code == 400 잘못된 이메일주소
+                Log.e("authApiFailed2", "Failed : ${response.headers()}")
+                Log.e("authApiFailed2", "${response.code()}")
+
+            }
+            isLoading = false
+        }
+    }
+
+    fun verifyChangePw(token: String, newPw: String) {
+        viewModelScope.launch {
+
+            val response = signUpApi.verifyChangePw(token)
+
+            if (response.code() == 304) { //성공
+                Log.e("authApiSuccess2", "${response.headers()}")
+                Log.e("authApiSuccess2", "${response.code()}")
+                resetPw(token, newPw)
+            } else {
+                // code == 404 유효하지 않은토큰. 토큰을 못받았거나 10분이 지났거나
+                Log.e("authApiFailed2", "Failed : ${response.headers()}")
+                Log.e("authApiFailed2", "${response.code()}")
+            }
+        }
+    }
+
+    private suspend fun resetPw(token: String, newPw: String) {
+        val body = SignUpApi.ResetPwRequest(newPw, token)
+        val response = signUpApi.resetPw(body)
+
+        if (response.code() == 200) { //성공
+            Log.e("authApiSuccess2", "${response.code()}")
+        } else {
+            Log.e("authApiFailed2", "${response.code()}")
+        }
+    }
+}

--- a/app/src/main/java/com/echoist/linkedout/viewModels/ResetPwViewModel.kt
+++ b/app/src/main/java/com/echoist/linkedout/viewModels/ResetPwViewModel.kt
@@ -34,12 +34,10 @@ class ResetPwViewModel @Inject constructor(
                 //헤더에 토큰이 없다.
                 Token.accessToken = response.headers()["x-access-token"]?.takeIf { it.isNotEmpty() }
                     ?: Token.accessToken
-                isSendEmailVerifyApiFinished = true
             } else {
                 // code == 400 잘못된 이메일주소
                 Log.e("authApiFailed2", "Failed : ${response.headers()}")
                 Log.e("authApiFailed2", "${response.code()}")
-
             }
             isLoading = false
         }

--- a/app/src/main/java/com/echoist/linkedout/viewModels/SettingsViewModel.kt
+++ b/app/src/main/java/com/echoist/linkedout/viewModels/SettingsViewModel.kt
@@ -283,7 +283,11 @@ class SettingsViewModel @Inject constructor(
 
                 if (response.isSuccessful){
                     Token.accessToken = response.headers()["x-access-token"]?.takeIf { it.isNotEmpty() } ?: Token.accessToken
-                    navController.navigate("LoginPage")
+                    navController.navigate("LoginPage"){
+                        popUpTo(navController.graph.startDestinationId) {
+                            inclusive = true
+                        }
+                    }
                 }
                 else{
                     Log.e("탈퇴 실패", "코드 :  ${response.code()}")

--- a/app/src/main/java/com/echoist/linkedout/viewModels/SignUpViewModel.kt
+++ b/app/src/main/java/com/echoist/linkedout/viewModels/SignUpViewModel.kt
@@ -29,7 +29,7 @@ import kotlin.coroutines.suspendCoroutine
 
 @HiltViewModel
 class SignUpViewModel @Inject constructor(
-    private val signUpApi : SignUpApi,
+    private val signUpApi: SignUpApi,
     private val userApi: UserApi,
     private val exampleItems: ExampleItems,
     private val supportApi: SupportApi
@@ -49,28 +49,22 @@ class SignUpViewModel @Inject constructor(
     var isLoading by mutableStateOf(false)
     var errorCode by mutableStateOf(200)
 
-    fun getMyInfo() : UserInfo{
-        return exampleItems.myProfile
-    }
-    fun isEmailValid(email: String): Boolean {
-        return Patterns.EMAIL_ADDRESS.matcher(email).matches()
-    }
-
-    private suspend fun readMyInfo(){
+    // init 함수에서 호출
+    private suspend fun readMyInfo() {
         try {
             val response = userApi.getMyInfo()
 
             exampleItems.myProfile = response.data.user
             exampleItems.myProfile.essayStats = response.data.essayStats
 
-        }catch (_: Exception){
+        } catch (_: Exception) {
             Log.d(TAG, "readMyInfo: error err")
         }
     }
 
     //이메일 중복검사 1차
     var isSignUpApiFinished by mutableStateOf(false)
-    fun getUserEmailCheck(userEmail: String,navController: NavController) {
+    fun getUserEmailCheck(userEmail: String, navController: NavController) {
 
         viewModelScope.launch {
             isLoading = true
@@ -88,7 +82,7 @@ class SignUpViewModel @Inject constructor(
                     Log.e("authApiFailed1", "Failed : ${response.errorBody()}")
 
                     Log.e("authApiSuccess", "${response.code()}")
-                    if (response.code() == 409) Log.e(TAG, "getUserEmailCheck: 이미 사용중인 이메일입니다.", )
+                    if (response.code() == 409) Log.e(TAG, "getUserEmailCheck: 이미 사용중인 이메일입니다.")
                 }
 
             } catch (e: Exception) {
@@ -96,14 +90,13 @@ class SignUpViewModel @Inject constructor(
 
                 // api 요청 실패
                 Log.e("writeEssayApiFailed1", "Failed: ${e.message}")
-            }
-            finally {
+            } finally {
                 isLoading = false
             }
         }
     }
 
-    fun requestRegister(code : String,navController: NavController){ //6자리 코드
+    fun requestRegister(code: String, navController: NavController) { //6자리 코드
         viewModelScope.launch {
             isLoading = true
             try {
@@ -128,8 +121,9 @@ class SignUpViewModel @Inject constructor(
                 // api 요청 실패
                 Log.e("회원가입 요청 실패", "Failed: ${e.printStackTrace()}")
 
+            } finally {
+                isLoading = false
             }
-            finally { isLoading = false }
         }
     }
 
@@ -146,7 +140,8 @@ class SignUpViewModel @Inject constructor(
                 isSignUpApiFinished = true
 
                 Log.d("tokentoken", response.headers()["authorization"].toString())
-                Token.accessToken = response.headers()["x-access-token"]?.takeIf { it.isNotEmpty() } ?: Token.accessToken
+                Token.accessToken = response.headers()["x-access-token"]?.takeIf { it.isNotEmpty() }
+                    ?: Token.accessToken
             } else {
                 errorCode = response.code()
                 Log.e("authApiFailed2", "Failed : ${response.headers()}")
@@ -157,18 +152,18 @@ class SignUpViewModel @Inject constructor(
             errorCode = 500
             // api 요청 실패
             Log.e("writeEssayApiFailed2", "Failed: ${e.message}")
-        }
-        finally {
+        } finally {
             isLoading = false
 
         }
     }
 
 
-
     var isSendEmailVerifyApiFinished by mutableStateOf(false)
+
     //이메일변경용 메일요청
-    fun sendEmailVerificationForChange(email : String) { //코루틴스코프에서 순차적으로 수행된다. 뷰모델스코프는 위에걸로
+    // 이메일변경 viewModel 분리
+    fun sendEmailVerificationForChange(email: String) { //코루틴스코프에서 순차적으로 수행된다. 뷰모델스코프는 위에걸로
         isLoading = true
         viewModelScope.launch {
             try {
@@ -179,7 +174,9 @@ class SignUpViewModel @Inject constructor(
                     Log.e("authApiSuccess2", "${response.headers()}")
                     Log.e("authApiSuccess2", "${response.code()}")
 
-                    Token.accessToken = response.headers()["x-access-token"]?.takeIf { it.isNotEmpty() } ?: Token.accessToken
+                    Token.accessToken =
+                        response.headers()["x-access-token"]?.takeIf { it.isNotEmpty() }
+                            ?: Token.accessToken
                     readMyInfo()
                     isSendEmailVerifyApiFinished = true
 
@@ -191,15 +188,15 @@ class SignUpViewModel @Inject constructor(
             } catch (e: Exception) {
                 // api 요청 실패
                 Log.e("writeEssayApiFailed2", "Failed: ${e.message}")
-            }
-            finally {
-                isLoading=false
+            } finally {
+                isLoading = false
             }
         }
 
     }
 
-    fun requestChangePw(email : String){
+    // 비밀번호 변경 viewModel 분리
+    fun requestChangePw(email: String) {
         isLoading = true
         viewModelScope.launch {
             isLoading = true
@@ -210,10 +207,10 @@ class SignUpViewModel @Inject constructor(
                 Log.d("requestChangePw api header", "${response.headers()}")
                 Log.d("requestChangePw api code", "${response.code()}")
                 //헤더에 토큰이 없다.
-                Token.accessToken = response.headers()["x-access-token"]?.takeIf { it.isNotEmpty() } ?: Token.accessToken
+                Token.accessToken = response.headers()["x-access-token"]?.takeIf { it.isNotEmpty() }
+                    ?: Token.accessToken
                 isSendEmailVerifyApiFinished = true
-            }
-            else{
+            } else {
                 // code == 400 잘못된 이메일주소
                 Log.e("authApiFailed2", "Failed : ${response.headers()}")
                 Log.e("authApiFailed2", "${response.code()}")
@@ -224,7 +221,7 @@ class SignUpViewModel @Inject constructor(
         }
     }
 
-    fun verifyChangePw(token : String,newPw: String){
+    fun verifyChangePw(token: String, newPw: String) {
         viewModelScope.launch {
 
             val response = signUpApi.verifyChangePw(token)
@@ -232,9 +229,8 @@ class SignUpViewModel @Inject constructor(
             if (response.code() == 304) { //성공
                 Log.e("authApiSuccess2", "${response.headers()}")
                 Log.e("authApiSuccess2", "${response.code()}")
-                resetPw(token,newPw)
-            }
-            else{
+                resetPw(token, newPw)
+            } else {
                 // code == 404 유효하지 않은토큰. 토큰을 못받았거나 10분이 지났거나
                 Log.e("authApiFailed2", "Failed : ${response.headers()}")
                 Log.e("authApiFailed2", "${response.code()}")
@@ -243,17 +239,16 @@ class SignUpViewModel @Inject constructor(
         }
     }
 
-    private suspend fun resetPw(token : String, newPw : String)
-    {
-            val body = SignUpApi.ResetPwRequest(newPw,token)
-            val response = signUpApi.resetPw(body)
+    // 비밀번호 변경 viewModel 분리
+    private suspend fun resetPw(token: String, newPw: String) {
+        val body = SignUpApi.ResetPwRequest(newPw, token)
+        val response = signUpApi.resetPw(body)
 
-            if (response.code() == 200) { //성공
-                Log.e("authApiSuccess2", "${response.code()}")
-            }
-            else{
-                Log.e("authApiFailed2", "${response.code()}")
-            }
+        if (response.code() == 200) { //성공
+            Log.e("authApiSuccess2", "${response.code()}")
+        } else {
+            Log.e("authApiFailed2", "${response.code()}")
+        }
     }
 
     fun setAgreementOfSignUp(
@@ -264,7 +259,12 @@ class SignUpViewModel @Inject constructor(
         context: Context
     ) {
         val option = when {
-            marketingAgreement -> NotificationSettings(serviceAlertAgreement, serviceAlertAgreement, true)
+            marketingAgreement -> NotificationSettings(
+                serviceAlertAgreement,
+                serviceAlertAgreement,
+                true
+            )
+
             else -> NotificationSettings(viewed = true, report = true, marketing = false)
         }
 
@@ -278,7 +278,7 @@ class SignUpViewModel @Inject constructor(
                 Log.d("위치서비스 동의 등록 ", "2")
                 if (locationAgreement) {
                     val userInfo = UserInfo(locationConsent = true)
-                    val response = userApi.userUpdate( userInfo)
+                    val response = userApi.userUpdate(userInfo)
 
                     if (response.isSuccessful) {
                         Log.d(TAG, "위치서비스 동의 저장 성공: ${response.code()}")
@@ -289,7 +289,7 @@ class SignUpViewModel @Inject constructor(
 
                 // 사용자의 마케팅 동의
                 Log.d("약관 동의 저장시작", "3")
-                val response = supportApi.updateUserNotification( option)
+                val response = supportApi.updateUserNotification(option)
                 if (response.isSuccessful) {
                     Log.d(TAG, "마케팅 동의 저장 성공: ${response.code()}")
 
@@ -313,7 +313,7 @@ class SignUpViewModel @Inject constructor(
             // 서버에 토큰값 보내기 등의 작업을 여기서 처리할 수 있습니다.
             val body = SignUpApiImpl.RegisterDeviceRequest(ssaid, token)
             try {
-                val response = supportApi.requestRegisterDevice( body)
+                val response = supportApi.requestRegisterDevice(body)
                 if (response.isSuccessful) {
                     Log.i("FCM Token", "ssaid 값 : $ssaid \n FCM token 값 : $token")
                     Log.d("기기 등록 성공입니다.", "success: ")
@@ -346,7 +346,8 @@ class SignUpViewModel @Inject constructor(
     }
 
     private fun getSSAID(context: Context): String {
-        val deviceId = Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
+        val deviceId =
+            Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
         Log.d("DeviceID", "Device ID: $deviceId")
         return deviceId
     }

--- a/app/src/main/java/com/echoist/linkedout/viewModels/SignUpViewModel.kt
+++ b/app/src/main/java/com/echoist/linkedout/viewModels/SignUpViewModel.kt
@@ -4,13 +4,11 @@ import android.content.ContentValues.TAG
 import android.content.Context
 import android.provider.Settings
 import android.util.Log
-import android.util.Patterns
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import androidx.navigation.NavController
 import com.echoist.linkedout.api.SignUpApi
 import com.echoist.linkedout.api.SignUpApiImpl
 import com.echoist.linkedout.api.SupportApi
@@ -48,6 +46,8 @@ class SignUpViewModel @Inject constructor(
     var agreement_location by mutableStateOf(false)
     var agreement_serviceAlert by mutableStateOf(false)
 
+    var isSignUpApiFinished by mutableStateOf(false)
+
     var isLoading by mutableStateOf(false)
     var errorCode by mutableStateOf(200)
 
@@ -60,15 +60,12 @@ class SignUpViewModel @Inject constructor(
 
             exampleItems.myProfile = response.data.user
             exampleItems.myProfile.essayStats = response.data.essayStats
-
         } catch (_: Exception) {
             Log.d(TAG, "readMyInfo: error err")
         }
     }
 
-    var isSignUpApiFinished by mutableStateOf(false)
     fun getUserEmailCheck(userEmail: String) {
-
         viewModelScope.launch {
             isLoading = true
             try {
@@ -113,10 +110,8 @@ class SignUpViewModel @Inject constructor(
                     _navigateToComplete.value = true
                 } else {
                     errorCode = response.code()
-
                     Log.e("회원가입 요청 실패", "Failed: ${response.code()}")
                 }
-
             } catch (e: Exception) {
                 errorCode = 500
                 // api 요청 실패
@@ -133,7 +128,6 @@ class SignUpViewModel @Inject constructor(
     }
 
     private suspend fun emailVerify() {
-
         try {
             val userAccount = SignUpApi.UserAccount(userEmail, userPw)
             val response = signUpApi.emailVerify(userAccount)
@@ -150,14 +144,12 @@ class SignUpViewModel @Inject constructor(
                 Log.e("authApiFailed2", "Failed : ${response.headers()}")
                 Log.e("authApiSuccess2", "${response.code()}")
             }
-
         } catch (e: Exception) {
             errorCode = 500
             // api 요청 실패
             Log.e("writeEssayApiFailed2", "Failed: ${e.message}")
         } finally {
             isLoading = false
-
         }
     }
 
@@ -260,5 +252,4 @@ class SignUpViewModel @Inject constructor(
         Log.d("DeviceID", "Device ID: $deviceId")
         return deviceId
     }
-
 }

--- a/app/src/main/java/com/echoist/linkedout/viewModels/SignUpViewModel.kt
+++ b/app/src/main/java/com/echoist/linkedout/viewModels/SignUpViewModel.kt
@@ -49,7 +49,6 @@ class SignUpViewModel @Inject constructor(
     var isLoading by mutableStateOf(false)
     var errorCode by mutableStateOf(200)
 
-    // init 함수에서 호출
     private suspend fun readMyInfo() {
         try {
             val response = userApi.getMyInfo()
@@ -62,7 +61,6 @@ class SignUpViewModel @Inject constructor(
         }
     }
 
-    //이메일 중복검사 1차
     var isSignUpApiFinished by mutableStateOf(false)
     fun getUserEmailCheck(userEmail: String, navController: NavController) {
 
@@ -127,8 +125,6 @@ class SignUpViewModel @Inject constructor(
         }
     }
 
-
-    //이메일 중복검사 2차
     private suspend fun emailVerify(navController: NavController) { //코루틴스코프에서 순차적으로 수행된다. 뷰모델스코프는 위에걸로
 
         try {
@@ -155,99 +151,6 @@ class SignUpViewModel @Inject constructor(
         } finally {
             isLoading = false
 
-        }
-    }
-
-
-    var isSendEmailVerifyApiFinished by mutableStateOf(false)
-
-    //이메일변경용 메일요청
-    // 이메일변경 viewModel 분리
-    fun sendEmailVerificationForChange(email: String) { //코루틴스코프에서 순차적으로 수행된다. 뷰모델스코프는 위에걸로
-        isLoading = true
-        viewModelScope.launch {
-            try {
-                val userEmail = SignUpApi.EmailRequest(email)
-                val response = signUpApi.sendEmailVerificationForChange(userEmail)
-
-                if (response.isSuccessful) {
-                    Log.e("authApiSuccess2", "${response.headers()}")
-                    Log.e("authApiSuccess2", "${response.code()}")
-
-                    Token.accessToken =
-                        response.headers()["x-access-token"]?.takeIf { it.isNotEmpty() }
-                            ?: Token.accessToken
-                    readMyInfo()
-                    isSendEmailVerifyApiFinished = true
-
-                } else {
-                    Log.e("authApiFailed2", "Failed : ${response.headers()}")
-                    Log.e("authApiFailed2", "${response.code()}")
-                }
-
-            } catch (e: Exception) {
-                // api 요청 실패
-                Log.e("writeEssayApiFailed2", "Failed: ${e.message}")
-            } finally {
-                isLoading = false
-            }
-        }
-
-    }
-
-    // 비밀번호 변경 viewModel 분리
-    fun requestChangePw(email: String) {
-        isLoading = true
-        viewModelScope.launch {
-            isLoading = true
-            val userEmail = SignUpApi.EmailRequest(email)
-            val response = signUpApi.requestChangePw(userEmail)
-
-            if (response.code() == 201) { //성공
-                Log.d("requestChangePw api header", "${response.headers()}")
-                Log.d("requestChangePw api code", "${response.code()}")
-                //헤더에 토큰이 없다.
-                Token.accessToken = response.headers()["x-access-token"]?.takeIf { it.isNotEmpty() }
-                    ?: Token.accessToken
-                isSendEmailVerifyApiFinished = true
-            } else {
-                // code == 400 잘못된 이메일주소
-                Log.e("authApiFailed2", "Failed : ${response.headers()}")
-                Log.e("authApiFailed2", "${response.code()}")
-
-            }
-            isLoading = false
-
-        }
-    }
-
-    fun verifyChangePw(token: String, newPw: String) {
-        viewModelScope.launch {
-
-            val response = signUpApi.verifyChangePw(token)
-
-            if (response.code() == 304) { //성공
-                Log.e("authApiSuccess2", "${response.headers()}")
-                Log.e("authApiSuccess2", "${response.code()}")
-                resetPw(token, newPw)
-            } else {
-                // code == 404 유효하지 않은토큰. 토큰을 못받았거나 10분이 지났거나
-                Log.e("authApiFailed2", "Failed : ${response.headers()}")
-                Log.e("authApiFailed2", "${response.code()}")
-            }
-
-        }
-    }
-
-    // 비밀번호 변경 viewModel 분리
-    private suspend fun resetPw(token: String, newPw: String) {
-        val body = SignUpApi.ResetPwRequest(newPw, token)
-        val response = signUpApi.resetPw(body)
-
-        if (response.code() == 200) { //성공
-            Log.e("authApiSuccess2", "${response.code()}")
-        } else {
-            Log.e("authApiFailed2", "${response.code()}")
         }
     }
 


### PR DESCRIPTION
1. ChangeEmailViewModel, ResetPwViewModel 분리
2. 아이디 변경, 비밀번호 재설정, 비밀번호 변경 기능 추가
해당 작업은 태블릿이 아닌 모바일만 봐주시면 될 것 같아여. 태블릿은 바꿔야 하는 부분이 많을 것으로 보여서 따로 브랜치 파서 작업하겠습니다. 