### PR TITLE
[Refactor] 프로필 편집 

### DIFF
--- a/app/src/main/java/com/echoist/linkedout/Extensions.kt
+++ b/app/src/main/java/com/echoist/linkedout/Extensions.kt
@@ -1,7 +1,37 @@
 package com.echoist.linkedout
 
+import android.content.ContentResolver
+import android.content.Context
+import android.net.Uri
+import android.provider.OpenableColumns
 import android.util.Patterns
+import java.io.File
+import java.io.FileOutputStream
+import java.io.InputStream
 
 fun String.isEmailValid(): Boolean {
     return Patterns.EMAIL_ADDRESS.matcher(this).matches()
+}
+
+fun getFileFromUri(uri: Uri, context: Context): File {
+    val contentResolver = context.contentResolver
+    val fileName = getFileName(uri, contentResolver)
+    val file = File(context.cacheDir, fileName.toString())
+    val inputStream: InputStream? = contentResolver.openInputStream(uri)
+    val outputStream = FileOutputStream(file)
+    inputStream?.copyTo(outputStream)
+    inputStream?.close()
+    outputStream.close()
+    return file
+}
+
+private fun getFileName(uri: Uri, contentResolver: ContentResolver): String? {
+    var name: String? = null
+    val cursor = contentResolver.query(uri, null, null, null, null)
+    cursor?.use {
+        if (it.moveToFirst()) {
+            name = it.getString(it.getColumnIndexOrThrow(OpenableColumns.DISPLAY_NAME))
+        }
+    }
+    return name
 }

--- a/app/src/main/java/com/echoist/linkedout/navigation/MobileApp.kt
+++ b/app/src/main/java/com/echoist/linkedout/navigation/MobileApp.kt
@@ -61,7 +61,7 @@ import com.echoist.linkedout.page.settings.ResetPwPageWithEmail
 import com.echoist.linkedout.viewModels.CommunityViewModel
 import com.echoist.linkedout.viewModels.HomeViewModel
 import com.echoist.linkedout.viewModels.MyLogViewModel
-import com.echoist.linkedout.viewModels.SettingsViewModel
+import com.echoist.linkedout.viewModels.MyPageViewModel
 import com.echoist.linkedout.viewModels.SignUpViewModel
 import com.echoist.linkedout.viewModels.SupportViewModel
 import com.echoist.linkedout.viewModels.WritingViewModel
@@ -76,7 +76,7 @@ fun MobileApp(
     val signUpViewModel: SignUpViewModel = hiltViewModel()
     val myLogViewModel: MyLogViewModel = hiltViewModel()
     val communityViewModel: CommunityViewModel = hiltViewModel()
-    val settingsViewModel: SettingsViewModel = hiltViewModel()
+    val settingsViewModel: MyPageViewModel = hiltViewModel()
     val supportViewModel: SupportViewModel = hiltViewModel()
 
     NavHost(

--- a/app/src/main/java/com/echoist/linkedout/page/settings/AccountPage.kt
+++ b/app/src/main/java/com/echoist/linkedout/page/settings/AccountPage.kt
@@ -54,10 +54,10 @@ import com.echoist.linkedout.SharedPreferencesUtil
 import com.echoist.linkedout.data.UserInfo
 import com.echoist.linkedout.page.home.LogoutBox
 import com.echoist.linkedout.ui.theme.LinkedInColor
-import com.echoist.linkedout.viewModels.SettingsViewModel
+import com.echoist.linkedout.viewModels.MyPageViewModel
 
 @Composable
-fun AccountPage(navController: NavController, viewModel: SettingsViewModel = hiltViewModel()) {
+fun AccountPage(navController: NavController, viewModel: MyPageViewModel = hiltViewModel()) {
     val scrollState = rememberScrollState()
     val context = LocalContext.current
 

--- a/app/src/main/java/com/echoist/linkedout/page/settings/AccountWithdrawalPage.kt
+++ b/app/src/main/java/com/echoist/linkedout/page/settings/AccountWithdrawalPage.kt
@@ -53,14 +53,14 @@ import com.echoist.linkedout.R
 import com.echoist.linkedout.SharedPreferencesUtil
 import com.echoist.linkedout.page.community.ReportTextField
 import com.echoist.linkedout.ui.theme.LinkedInColor
-import com.echoist.linkedout.viewModels.SettingsViewModel
+import com.echoist.linkedout.viewModels.MyPageViewModel
 
 @OptIn(ExperimentalGlideComposeApi::class)
 @Composable
 fun AccountWithdrawalPage(navController: NavController) {
 
     val scrollState = rememberScrollState()
-    val viewModel: SettingsViewModel = hiltViewModel()
+    val viewModel: MyPageViewModel = hiltViewModel()
 
     var isWithdrawalClicked by remember { mutableStateOf(false) }
     val reasonList = listOf(

--- a/app/src/main/java/com/echoist/linkedout/page/settings/BadgePage.kt
+++ b/app/src/main/java/com/echoist/linkedout/page/settings/BadgePage.kt
@@ -64,10 +64,10 @@ import androidx.navigation.NavController
 import com.echoist.linkedout.R
 import com.echoist.linkedout.data.BadgeBoxItemWithTag
 import com.echoist.linkedout.page.home.MyBottomNavigation
-import com.echoist.linkedout.viewModels.SettingsViewModel
+import com.echoist.linkedout.viewModels.MyPageViewModel
 
 @Composable
-fun BadgePage(navController: NavController, viewModel: SettingsViewModel) {
+fun BadgePage(navController: NavController, viewModel: MyPageViewModel) {
     val hasCalledApi = remember { mutableStateOf(false) }
 
     val badgeBoxItems = viewModel.getDetailBadgeList()
@@ -125,7 +125,7 @@ fun BadgeTopAppBar(navController: NavController) {
 }
 
 @Composable
-fun BadgeItem(badgeBoxItem: BadgeBoxItemWithTag, viewModel: SettingsViewModel) {
+fun BadgeItem(badgeBoxItem: BadgeBoxItemWithTag, viewModel: MyPageViewModel) {
     val badgeTagList = badgeBoxItem.tags
     var isClicked by remember { mutableStateOf(false) }
     val arrowImage = if (isClicked) R.drawable.arrowup else R.drawable.arrowdown
@@ -291,7 +291,7 @@ fun BadgeImg(badgeBoxItem: BadgeBoxItemWithTag) {
 
 //레벨업 보상획득 시 페이지
 @Composable
-fun BadgeLevelUpSuccess(viewModel: SettingsViewModel, badgeBoxItem: BadgeBoxItemWithTag) {
+fun BadgeLevelUpSuccess(viewModel: MyPageViewModel, badgeBoxItem: BadgeBoxItemWithTag) {
 
     AnimatedVisibility(
         viewModel.isLevelUpSuccess,

--- a/app/src/main/java/com/echoist/linkedout/page/settings/ChangePwPage.kt
+++ b/app/src/main/java/com/echoist/linkedout/page/settings/ChangePwPage.kt
@@ -32,10 +32,10 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import com.echoist.linkedout.ui.theme.LinkedInColor
-import com.echoist.linkedout.viewModels.SettingsViewModel
+import com.echoist.linkedout.viewModels.MyPageViewModel
 
 @Composable
-fun ChangePwPage(navController: NavController, viewModel: SettingsViewModel = hiltViewModel()) {
+fun ChangePwPage(navController: NavController, viewModel: MyPageViewModel = hiltViewModel()) {
 
     val scrollState = rememberScrollState()
     LaunchedEffect(true) {

--- a/app/src/main/java/com/echoist/linkedout/page/settings/ChangePwPage.kt
+++ b/app/src/main/java/com/echoist/linkedout/page/settings/ChangePwPage.kt
@@ -130,8 +130,8 @@ fun ChangePwPage(navController: NavController, viewModel: MyPageViewModel = hilt
                 val enabled = newPw == newPwCheck && newPw.isNotBlank() //문자가 있어야함
                 Button(
                     onClick = {
-                        viewModel.updateMyInfo(
-                            viewModel.newProfile.copy(password = newPw),
+                        viewModel.updatePw(
+                            newPw,
                             navController
                         )
                     },

--- a/app/src/main/java/com/echoist/linkedout/page/settings/MyPage.kt
+++ b/app/src/main/java/com/echoist/linkedout/page/settings/MyPage.kt
@@ -107,7 +107,7 @@ import com.echoist.linkedout.data.UserInfo
 import com.echoist.linkedout.page.home.MyBottomNavigation
 import com.echoist.linkedout.ui.theme.LinkedInColor
 import com.echoist.linkedout.viewModels.CommunityViewModel
-import com.echoist.linkedout.viewModels.SettingsViewModel
+import com.echoist.linkedout.viewModels.MyPageViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
@@ -116,7 +116,7 @@ import kotlinx.coroutines.launch
 @Composable
 fun MyPage(
     navController: NavController,
-    viewModel: SettingsViewModel = hiltViewModel()
+    viewModel: MyPageViewModel = hiltViewModel()
 ) {
 
     var isApiFinished by remember {
@@ -459,7 +459,7 @@ fun RecentEssayList(itemList: List<EssayApi.EssayItem>, navController: NavContro
 }
 
 @Composable
-fun BadgeDescriptionBox(badgeBoxItem: BadgeBoxItem, viewModel: SettingsViewModel) {
+fun BadgeDescriptionBox(badgeBoxItem: BadgeBoxItem, viewModel: MyPageViewModel) {
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -522,7 +522,7 @@ fun BadgeDescriptionBox(badgeBoxItem: BadgeBoxItem, viewModel: SettingsViewModel
 @Composable
 fun LinkedOutBadgeItem(
     badgeBoxItem: BadgeBoxItem,
-    viewModel: SettingsViewModel
+    viewModel: MyPageViewModel
 ) {
     // 기본 Modifier 정의
     val baseModifier = Modifier
@@ -567,7 +567,7 @@ fun LinkedOutBadgeItem(
 
 
 @Composable
-fun LinkedOutBadgeGrid(viewModel: SettingsViewModel) {
+fun LinkedOutBadgeGrid(viewModel: MyPageViewModel) {
     val badgeList by remember {
         mutableStateOf(viewModel.getSimpleBadgeList())
     }
@@ -601,7 +601,7 @@ fun LinkedOutBadgeGrid(viewModel: SettingsViewModel) {
 }
 
 @Composable
-fun ModifyNickNameTextField(viewModel: SettingsViewModel) {
+fun ModifyNickNameTextField(viewModel: MyPageViewModel) {
 
     var text by remember { mutableStateOf(viewModel.getMyInfo().nickname ?: "에러") }
     var message by remember {
@@ -663,7 +663,7 @@ fun ModifyNickNameTextField(viewModel: SettingsViewModel) {
 fun ModifyMyProfileBottomSheet(
     onClickComplete: () -> Unit,
     onClickCancel: () -> Unit,
-    viewModel: SettingsViewModel
+    viewModel: MyPageViewModel
 ) {
     val focusManager = LocalFocusManager.current
 
@@ -783,7 +783,7 @@ fun SelectProfileImageIcon(onClickModifyImage: () -> Unit, imageUrl: String) {
 
 @OptIn(ExperimentalGlideComposeApi::class, ExperimentalMaterial3Api::class)
 @Composable
-fun SelectProfileIconBottomSheet(viewModel: SettingsViewModel) {
+fun SelectProfileIconBottomSheet(viewModel: MyPageViewModel) {
 
     val context = LocalContext.current
     val scope = rememberCoroutineScope()

--- a/app/src/main/java/com/echoist/linkedout/page/settings/MyPage.kt
+++ b/app/src/main/java/com/echoist/linkedout/page/settings/MyPage.kt
@@ -98,6 +98,7 @@ import com.echoist.linkedout.PROFILE_IMAGE_10
 import com.echoist.linkedout.PROFILE_IMAGE_11
 import com.echoist.linkedout.PROFILE_IMAGE_12
 import com.echoist.linkedout.R
+import com.echoist.linkedout.Routes
 import com.echoist.linkedout.TYPE_RECOMMEND
 import com.echoist.linkedout.api.EssayApi
 import com.echoist.linkedout.data.BadgeBoxItem
@@ -114,7 +115,8 @@ import kotlinx.coroutines.launch
 @Composable
 fun MyPage(
     navController: NavController,
-    viewModel: MyPageViewModel = hiltViewModel()
+    viewModel: MyPageViewModel = hiltViewModel(),
+    communityViewModel: CommunityViewModel = hiltViewModel()
 ) {
     val context = LocalContext.current
     val scrollState = rememberScrollState()
@@ -212,10 +214,13 @@ fun MyPage(
                         SettingBar("링크드아웃 배지") { viewModel.readDetailBadgeList(navController) }
                         LinkedOutBadgeGrid(viewModel)
                         SettingBar("최근 본 글") { navController.navigate("RecentViewedEssayPage") }
-                        RecentEssayList(
-                            itemList = viewModel.getRecentViewedEssayList(),
-                            navController
-                        )
+                        RecentEssayList(itemList = viewModel.getRecentViewedEssayList()) {
+                            communityViewModel.readDetailRecentEssay(
+                                it,
+                                navController,
+                                TYPE_RECOMMEND
+                            )
+                        }
                         MembershipSettingBar("멤버십 관리") {}
                         SettingBar("계정 관리") { navController.navigate("AccountPage") }
                     }
@@ -409,13 +414,12 @@ fun MembershipSettingBar(text: String, onClick: () -> Unit) {
 @Composable
 fun RecentEssayItem(
     item: EssayApi.EssayItem,
-    viewModel: CommunityViewModel = hiltViewModel(),
-    navController: NavController
+    onClickEssayItem: (Int) -> Unit
 ) {
     Box(modifier = Modifier
         .size(150.dp, 120.dp)
         .clickable { /* 에세이로 이동 */
-            viewModel.readDetailRecentEssay(item.id!!, navController, TYPE_RECOMMEND)
+            onClickEssayItem(item.id!!)
         }) {
         Column {
             Text(text = item.title!!)
@@ -432,7 +436,10 @@ fun RecentEssayItem(
 }
 
 @Composable
-fun RecentEssayList(itemList: List<EssayApi.EssayItem>, navController: NavController) {
+fun RecentEssayList(
+    itemList: List<EssayApi.EssayItem>,
+    onClickEssayItem: (Int) -> Unit
+) {
     if (itemList.isEmpty()) {
         Text(
             text = "최근 본 글이 없습니다.",
@@ -442,7 +449,7 @@ fun RecentEssayList(itemList: List<EssayApi.EssayItem>, navController: NavContro
     } else {
         LazyRow(Modifier.padding(start = 20.dp)) {
             itemsIndexed(itemList) { index, item ->
-                RecentEssayItem(item, navController = navController)
+                RecentEssayItem(item, onClickEssayItem)
                 // 마지막 항목인 경우에만 Spacer와 VerticalDivider 실행
                 if (index < itemList.size - 1) {
                     Spacer(modifier = Modifier.width(10.dp))

--- a/app/src/main/java/com/echoist/linkedout/presentation/TabletAccountScreen.kt
+++ b/app/src/main/java/com/echoist/linkedout/presentation/TabletAccountScreen.kt
@@ -33,11 +33,11 @@ import com.echoist.linkedout.SharedPreferencesUtil
 import com.echoist.linkedout.page.home.LogoutBox
 import com.echoist.linkedout.page.settings.EmailBox
 import com.echoist.linkedout.page.settings.ModifyBox
-import com.echoist.linkedout.viewModels.SettingsViewModel
+import com.echoist.linkedout.viewModels.MyPageViewModel
 
 @Composable
 fun TabletAccountRoute(
-    viewModel: SettingsViewModel = hiltViewModel(),
+    viewModel: MyPageViewModel = hiltViewModel(),
     contentPadding: PaddingValues,
     onClickChangeEmail: () -> Unit,
     onClickChangePassword: () -> Unit,

--- a/app/src/main/java/com/echoist/linkedout/presentation/TabletBadgeScreen.kt
+++ b/app/src/main/java/com/echoist/linkedout/presentation/TabletBadgeScreen.kt
@@ -14,12 +14,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.echoist.linkedout.page.settings.BadgeItem
-import com.echoist.linkedout.viewModels.SettingsViewModel
+import com.echoist.linkedout.viewModels.MyPageViewModel
 
 @Composable
 fun TabletBadgeRoute(
     contentPadding: PaddingValues,
-    viewModel: SettingsViewModel = hiltViewModel()
+    viewModel: MyPageViewModel = hiltViewModel()
 ) {
     val hasCalledApi = remember { mutableStateOf(false) }
     val badgeBoxItems = viewModel.getDetailBadgeList()

--- a/app/src/main/java/com/echoist/linkedout/presentation/TabletDeleteAccountScreen.kt
+++ b/app/src/main/java/com/echoist/linkedout/presentation/TabletDeleteAccountScreen.kt
@@ -44,14 +44,14 @@ import com.echoist.linkedout.SharedPreferencesUtil
 import com.echoist.linkedout.page.settings.MultiSelectDeleteList
 import com.echoist.linkedout.page.settings.WithdrawalWarningBox
 import com.echoist.linkedout.ui.theme.LinkedInColor
-import com.echoist.linkedout.viewModels.SettingsViewModel
+import com.echoist.linkedout.viewModels.MyPageViewModel
 
 @OptIn(ExperimentalGlideComposeApi::class)
 @Composable
 fun TabletDeleteAccountRoute(contentPadding: PaddingValues, navController: NavController) {
 
     val scrollState = rememberScrollState()
-    val viewModel: SettingsViewModel = hiltViewModel()
+    val viewModel: MyPageViewModel = hiltViewModel()
 
     var isWithdrawalClicked by remember { mutableStateOf(false) }
     val reasonList = listOf(

--- a/app/src/main/java/com/echoist/linkedout/presentation/TabletMyInfoScreen.kt
+++ b/app/src/main/java/com/echoist/linkedout/presentation/TabletMyInfoScreen.kt
@@ -87,7 +87,6 @@ fun TabletMyInfoRoute(
                     )
                 )
             ) {
-                Log.d(ContentValues.TAG, "MyPage: ${viewModel.newProfile}")
                 //SelectProfileIconBottomSheet(viewModel)
             }
             //기본
@@ -143,7 +142,9 @@ fun TabletMyInfoRoute(
                 SettingBar("최근 본 글") { navController.navigate("RecentViewedEssayPage") }
                 RecentEssayList(
                     itemList = viewModel.getRecentViewedEssayList(),
-                    navController
+                    onClickEssayItem = { essayId ->
+                        // 에세이 디테일로 넘어가는 동작
+                    }
                 )
                 MembershipSettingBar("멤버십 관리") {}
                 SettingBar("계정 관리") { navController.navigate("AccountPage") }

--- a/app/src/main/java/com/echoist/linkedout/presentation/TabletMyInfoScreen.kt
+++ b/app/src/main/java/com/echoist/linkedout/presentation/TabletMyInfoScreen.kt
@@ -109,14 +109,16 @@ fun TabletMyInfoRoute(
             ) {
                 ModifyMyProfileBottomSheet(
                     onClickComplete = {
-                        viewModel.updateMyInfo(viewModel.newProfile, navController)
+                        viewModel.updateMyInfo(navController)
                     },
                     onClickCancel = {
                         scope.launch {
                             bottomSheetState.hide()
-
                         }
-                    }, viewModel
+                    },
+                    onClickImageChange = {
+                        viewModel.isClickedModifyImage = true
+                    }
                 )
             }
 

--- a/app/src/main/java/com/echoist/linkedout/presentation/TabletMyInfoScreen.kt
+++ b/app/src/main/java/com/echoist/linkedout/presentation/TabletMyInfoScreen.kt
@@ -37,7 +37,7 @@ import com.echoist.linkedout.page.settings.MySettings
 import com.echoist.linkedout.page.settings.RecentEssayList
 import com.echoist.linkedout.page.settings.SelectProfileIconBottomSheet
 import com.echoist.linkedout.page.settings.SettingBar
-import com.echoist.linkedout.viewModels.SettingsViewModel
+import com.echoist.linkedout.viewModels.MyPageViewModel
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -45,7 +45,7 @@ import kotlinx.coroutines.launch
 fun TabletMyInfoRoute(
     modifier: Modifier = Modifier,
     navController: NavController,
-    viewModel: SettingsViewModel = hiltViewModel()
+    viewModel: MyPageViewModel = hiltViewModel()
 ) {
     var isApiFinished by remember {
         mutableStateOf(false)
@@ -88,7 +88,7 @@ fun TabletMyInfoRoute(
                 )
             ) {
                 Log.d(ContentValues.TAG, "MyPage: ${viewModel.newProfile}")
-                SelectProfileIconBottomSheet(viewModel)
+                //SelectProfileIconBottomSheet(viewModel)
             }
             //기본
 

--- a/app/src/main/java/com/echoist/linkedout/viewModels/MyPageViewModel.kt
+++ b/app/src/main/java/com/echoist/linkedout/viewModels/MyPageViewModel.kt
@@ -208,6 +208,35 @@ class MyPageViewModel @Inject constructor(
         }
     }
 
+    fun updatePw(password: String, navController: NavController) {
+        viewModelScope.launch {
+            isLoading = true
+            try {
+                val response = userApi.userUpdate(tempProfile.value.copy(password = password))
+
+                if (response.isSuccessful) {
+                    Token.accessToken =
+                        response.headers()["x-access-token"]?.takeIf { it.isNotEmpty() }
+                            ?: Token.accessToken
+                    exampleItems.myProfile.profileImage = tempProfile.value.profileImage
+                    exampleItems.myProfile.nickname = tempProfile.value.nickname
+                    _userProfile.value = tempProfile.value
+                    readSimpleBadgeList()
+                    getMyInfo()
+                    navController.navigate("SETTINGS")
+                } else {
+                    Log.e("업데이트 요청 실패", "updateMyInfo: ${response.code()}")
+                }
+            } catch (e: Exception) {
+                e.printStackTrace()
+                // api 요청 실패
+                Log.e("업데이트 요청 실패", "updateMyInfo: ${e.printStackTrace()}")
+            } finally {
+                isLoading = false
+            }
+        }
+    }
+
     var isApiFinished by mutableStateOf(false)
     fun readRecentEssays() {
         isApiFinished = false

--- a/app/src/main/java/com/echoist/linkedout/viewModels/MyPageViewModel.kt
+++ b/app/src/main/java/com/echoist/linkedout/viewModels/MyPageViewModel.kt
@@ -37,7 +37,6 @@ class MyPageViewModel @Inject constructor(
     private val userApi: UserApi,
     private val exampleItems: ExampleItems
 ) : ViewModel() {
-    var newProfile by mutableStateOf(UserInfo())
     var isClickedModifyImage by mutableStateOf(false)
 
     var isLevelUpSuccess by mutableStateOf(false)

--- a/app/src/main/java/com/echoist/linkedout/viewModels/MyPageViewModel.kt
+++ b/app/src/main/java/com/echoist/linkedout/viewModels/MyPageViewModel.kt
@@ -1,10 +1,8 @@
 package com.echoist.linkedout.viewModels
 
-import android.content.ContentResolver
 import android.content.ContentValues.TAG
 import android.content.Context
 import android.net.Uri
-import android.provider.OpenableColumns
 import android.util.Log
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -21,28 +19,25 @@ import com.echoist.linkedout.data.BadgeBoxItemWithTag
 import com.echoist.linkedout.data.ExampleItems
 import com.echoist.linkedout.data.UserInfo
 import com.echoist.linkedout.data.toBadgeBoxItem
+import com.echoist.linkedout.getFileFromUri
 import com.echoist.linkedout.page.myLog.Token
-import com.echoist.linkedout.page.myLog.Token.bearerAccessToken
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.MultipartBody
 import okhttp3.RequestBody.Companion.asRequestBody
-import java.io.File
-import java.io.FileOutputStream
-import java.io.InputStream
 import javax.inject.Inject
 
 @HiltViewModel
-class SettingsViewModel @Inject constructor(
+class MyPageViewModel @Inject constructor(
     private val essayApi: EssayApi,
     private val userApi: UserApi,
     private val exampleItems: ExampleItems
 ) : ViewModel() {
-    var isClickedModifyImage by mutableStateOf(false)
-
     var newProfile by mutableStateOf(UserInfo())
+    var isClickedModifyImage by mutableStateOf(false)
 
     var isLevelUpSuccess by mutableStateOf(false)
 
@@ -51,63 +46,43 @@ class SettingsViewModel @Inject constructor(
 
     var isLoading by mutableStateOf(false)
 
-    fun getFileFromUri(uri: Uri, context: Context): File {
-        val contentResolver = context.contentResolver
-        val fileName = getFileName(uri, contentResolver)
-        val file = File(context.cacheDir, fileName.toString())
-        val inputStream: InputStream? = contentResolver.openInputStream(uri)
-        val outputStream = FileOutputStream(file)
-        inputStream?.copyTo(outputStream)
-        inputStream?.close()
-        outputStream.close()
-        return file
-    }
+    private val _newProfile = MutableStateFlow(UserInfo())
+    //val newProfile: StateFlow<UserInfo> = _newProfile
 
-    private fun getFileName(uri: Uri, contentResolver: ContentResolver): String? {
-        var name: String? = null
-        val cursor = contentResolver.query(uri, null, null, null, null)
-        cursor?.use {
-            if (it.moveToFirst()) {
-                name = it.getString(it.getColumnIndexOrThrow(OpenableColumns.DISPLAY_NAME))
-            }
-        }
-        return name
-    }
-
+    // mypageViewModel 분리
     suspend fun uploadImage(uri: Uri, context: Context): String? { //서버에 이미지 업로드하고 url을 반환
+        try {
+            val file = getFileFromUri(uri, context)
+            val requestFile = file.asRequestBody("image/jpeg".toMediaTypeOrNull())
+            val body = MultipartBody.Part.createFormData("image", file.name, requestFile)
 
-            try {
-                val file = getFileFromUri(uri, context)
-                val requestFile = file.asRequestBody("image/jpeg".toMediaTypeOrNull())
-                val body = MultipartBody.Part.createFormData("image", file.name, requestFile)
+            // 서버로 업로드 요청 보내기
+            val response = userApi.userImageUpload(body)
 
-                // 서버로 업로드 요청 보내기
-                val response = userApi.userImageUpload( body)
-
-                if (response.isSuccessful){
-                    newProfile.profileImage = response.body()!!.data.imageUrl
-                    exampleItems.myProfile.profileImage = response.body()!!.data.imageUrl
-                    return response.body()!!.data.imageUrl
-                }else
-                    return  null
-
-                // 서버 응답에서 URL 추출
-            } catch (e: Exception) {
-                e.printStackTrace()
+            if (response.isSuccessful) {
+                _newProfile.value.profileImage = response.body()!!.data.imageUrl
+                exampleItems.myProfile.profileImage = response.body()!!.data.imageUrl
+                return response.body()!!.data.imageUrl
+            } else
                 return null
-            } finally {
 
-            }
-
+            // 서버 응답에서 URL 추출
+        } catch (e: Exception) {
+            e.printStackTrace()
+            return null
+        } finally {
+        }
     }
-    fun getRecentViewedEssayList() : List<EssayApi.EssayItem>{
+
+    // mypageViewModel 분리
+    fun getRecentViewedEssayList(): List<EssayApi.EssayItem> {
         return exampleItems.recentViewedEssayList
     }
 
-    fun requestMyInfo(){
+    // mypageViewModel 분리
+    fun requestMyInfo() {
         viewModelScope.launch {
             try {
-
                 val response = userApi.getMyInfo()
 
                 Log.d(TAG, "readMyInfo: suc1")
@@ -115,21 +90,17 @@ class SettingsViewModel @Inject constructor(
                 exampleItems.myProfile.essayStats = response.data.essayStats
                 Log.i(TAG, "readMyInfo: ${exampleItems.myProfile}")
                 getMyInfo()
-
-            }catch (e: Exception){
+            } catch (e: Exception) {
                 Log.d(TAG, "readMyInfo: error err")
                 e.printStackTrace()
                 Log.d(TAG, e.message.toString())
                 Log.d(TAG, e.cause.toString())
-
-
             }
         }
-
     }
 
-
-    fun getMyInfo() : UserInfo{
+    // mypageViewModel, AccountViewModel 분리
+    fun getMyInfo(): UserInfo {
         Log.d("example item", "readMyInfo: ${exampleItems.myProfile}")
         return exampleItems.myProfile
     }
@@ -139,26 +110,25 @@ class SettingsViewModel @Inject constructor(
         viewModelScope.launch {
             try {
                 //readMyInfo()
-                val response = userApi.readBadgeList( )
+                val response = userApi.readBadgeList()
                 Log.d(TAG, "readSimpleBadgeList: ${response.body()!!.data.badges}")
-                response.body()?.data?.badges!!.let{badges ->
-                    exampleItems.simpleBadgeList = badges.map { it.toBadgeBoxItem() }.toMutableStateList()
+                response.body()?.data?.badges!!.let { badges ->
+                    exampleItems.simpleBadgeList =
+                        badges.map { it.toBadgeBoxItem() }.toMutableStateList()
                 }
                 Log.d(TAG, "readSimpleBadgeList: ${exampleItems.simpleBadgeList}")
-                Token.accessToken = response.headers()["x-access-token"]?.takeIf { it.isNotEmpty() } ?: Token.accessToken
-
-
+                Token.accessToken = response.headers()["x-access-token"]?.takeIf { it.isNotEmpty() }
+                    ?: Token.accessToken
             } catch (e: Exception) {
                 e.printStackTrace()
                 // api 요청 실패
                 Log.e("writeEssayApiFailed", "Failed to write essay: ${e.message}")
                 Log.e("writeEssayApiFailed", "Failed to write essay: ${e.localizedMessage}")
-
             }
         }
     }
 
-    fun getSimpleBadgeList() : List<BadgeBoxItem>{
+    fun getSimpleBadgeList(): List<BadgeBoxItem> {
         return exampleItems.simpleBadgeList.toList()
     }
 
@@ -168,11 +138,12 @@ class SettingsViewModel @Inject constructor(
                 val response = userApi.readBadgeWithTagsList()
                 response.body()?.data?.badges?.let { badges ->
                     // badges 리스트를 SnapshotStateList로 변환
-                    exampleItems.detailBadgeList = badges.map { it.toBadgeBoxItem() }.toMutableStateList() as SnapshotStateList<BadgeBoxItemWithTag>
+                    exampleItems.detailBadgeList = badges.map { it.toBadgeBoxItem() }
+                        .toMutableStateList() as SnapshotStateList<BadgeBoxItemWithTag>
                 }
                 Log.d(TAG, "readdetailList: ${exampleItems.detailBadgeList}")
-                Token.accessToken = response.headers()["x-access-token"]?.takeIf { it.isNotEmpty() } ?: Token.accessToken
-
+                Token.accessToken = response.headers()["x-access-token"]?.takeIf { it.isNotEmpty() }
+                    ?: Token.accessToken
 
                 navController.navigate("BadgePage")
             } catch (e: Exception) {
@@ -183,25 +154,25 @@ class SettingsViewModel @Inject constructor(
         }
     }
 
-    fun getDetailBadgeList() : List<BadgeBoxItemWithTag>{
+    fun getDetailBadgeList(): List<BadgeBoxItemWithTag> {
         return exampleItems.detailBadgeList.toList()
     }
 
-    fun requestBadgeLevelUp(badgeId : Int) {
+    // badgeViewModel 분리
+    fun requestBadgeLevelUp(badgeId: Int) {
         viewModelScope.launch {
             try {
-
-                val response = userApi.requestBadgeLevelUp( badgeId)
+                val response = userApi.requestBadgeLevelUp(badgeId)
                 Log.d(TAG, "requestBadgeLevelUp: ${Token.accessToken}")
 
-                Token.accessToken = response.headers()["x-access-token"]?.takeIf { it.isNotEmpty() } ?: Token.accessToken
+                Token.accessToken = response.headers()["x-access-token"]?.takeIf { it.isNotEmpty() }
+                    ?: Token.accessToken
 
-                if (response.body()!!.success){
+                if (response.body()!!.success) {
                     isLevelUpSuccess = true
                     delay(1000)
                     isLevelUpSuccess = false
                 }
-
             } catch (e: Exception) {
                 e.printStackTrace()
                 // api 요청 실패
@@ -210,117 +181,103 @@ class SettingsViewModel @Inject constructor(
         }
     }
 
-    fun updateMyInfo(userInfo: UserInfo,navController: NavController) {
+    fun updateMyInfo(userInfo: UserInfo, navController: NavController) {
         viewModelScope.launch {
             isLoading = true
             try {
+                val response = userApi.userUpdate(userInfo)
 
-                val response = userApi.userUpdate( userInfo)
-
-                if (response.isSuccessful){
-                    Token.accessToken = response.headers()["x-access-token"]?.takeIf { it.isNotEmpty() } ?: Token.accessToken
-
-                    Log.d("업데이트 요청 성공", "updateMyInfo: ${newProfile.profileImage}")
-
-                    exampleItems.myProfile.profileImage = newProfile.profileImage
-                    exampleItems.myProfile.nickname = newProfile.nickname
-
+                if (response.isSuccessful) {
+                    Token.accessToken =
+                        response.headers()["x-access-token"]?.takeIf { it.isNotEmpty() }
+                            ?: Token.accessToken
+                    exampleItems.myProfile.profileImage = _newProfile.value.profileImage
+                    exampleItems.myProfile.nickname = _newProfile.value.nickname
                     readSimpleBadgeList()
                     getMyInfo()
                     navController.navigate("SETTINGS")
-                    newProfile = UserInfo()
-
-                }
-                else{
+                    _newProfile.value = UserInfo()
+                } else {
                     Log.e("업데이트 요청 실패", "updateMyInfo: ${response.code()}")
-
                 }
             } catch (e: Exception) {
                 e.printStackTrace()
                 // api 요청 실패
                 Log.e("업데이트 요청 실패", "updateMyInfo: ${e.printStackTrace()}")
-
-            }
-            finally {
+            } finally {
                 isLoading = false
             }
         }
     }
 
     var isApiFinished by mutableStateOf(false)
-    fun readRecentEssays(){
+    fun readRecentEssays() {
         isApiFinished = false
         viewModelScope.launch {
             isLoading = true
-
             try {
                 val response = essayApi.readRecentEssays()
-
-                if (response.isSuccessful){
-                                        Token.accessToken = response.headers()["x-access-token"]?.takeIf { it.isNotEmpty() } ?: Token.accessToken
-                    exampleItems.recentViewedEssayList = response.body()!!.data.essays.toMutableStateList()
+                if (response.isSuccessful) {
+                    Token.accessToken =
+                        response.headers()["x-access-token"]?.takeIf { it.isNotEmpty() }
+                            ?: Token.accessToken
+                    exampleItems.recentViewedEssayList =
+                        response.body()!!.data.essays.toMutableStateList()
                     isApiFinished = true
                 }
             } catch (e: Exception) {
                 e.printStackTrace()
                 // api 요청 실패
                 Log.e("writeEssayApiFailed", "Failed to write essay: ${e.message}")
-            }
-            finally {
+            } finally {
                 isLoading = false
             }
         }
     }
 
-    fun requestWithdrawal(reasons : List<String>, navController: NavController){
+    fun requestWithdrawal(reasons: List<String>, navController: NavController) {
         viewModelScope.launch {
             isLoading = true
             try {
-
                 val body = UserApi.RequestDeactivate(reasons)
                 val response = userApi.requestDeactivate(body)
                 Log.d(TAG, "requestWithdrawal: $reasons")
-
-                if (response.isSuccessful){
-                    Token.accessToken = response.headers()["x-access-token"]?.takeIf { it.isNotEmpty() } ?: Token.accessToken
-                    navController.navigate("LoginPage"){
+                if (response.isSuccessful) {
+                    Token.accessToken =
+                        response.headers()["x-access-token"]?.takeIf { it.isNotEmpty() }
+                            ?: Token.accessToken
+                    navController.navigate("LoginPage") {
                         popUpTo(navController.graph.startDestinationId) {
                             inclusive = true
                         }
                     }
-                }
-                else{
+                } else {
                     Log.e("탈퇴 실패", "코드 :  ${response.code()}")
                 }
-            }catch (e: Exception) {
+            } catch (e: Exception) {
                 e.printStackTrace()
                 // api 요청 실패
                 Log.e("탈퇴 요청 실패", "${e.message}")
-            }
-            finally {
+            } finally {
                 isLoading = false
             }
         }
     }
 
     var nicknameCheckCode by mutableStateOf(200)
-    fun requestNicknameDuplicated(nickname : String){
+    fun requestNicknameDuplicated(nickname: String) {
         viewModelScope.launch {
             try {
-
                 val nickname = UserApi.NickName(nickname)
                 val response = userApi.requestNicknameDuplicated(nickname)
                 Log.d("닉네임 중복검사", "requestNicknameDuplicated: $nickname")
-
-                if (response.isSuccessful){ //실시간요청이기때문에 토큰사용 x
+                if (response.isSuccessful) { //실시간요청이기때문에 토큰사용 x
                     //                    Token.accessToken = response.headers()["x-access-token"]?.takeIf { it.isNotEmpty() } ?: Token.accessToken
                     Log.d("닉네임 중복검사 성공", "코드: ${response.code()}")
                     nicknameCheckCode = response.code()
-                }
-                else{
+                } else {
                     Log.e("닉네임 중복검사 실패", "코드: ${response.code()}")
                     nicknameCheckCode = response.code()
-
                 }
             } catch (e: Exception) {
                 e.printStackTrace()
@@ -329,5 +286,4 @@ class SettingsViewModel @Inject constructor(
             }
         }
     }
-
 }


### PR DESCRIPTION
작업 내용
1. SettingsViewModel -> MyPageViewModel 이름 변경
2. 기존 viewModel.getMyInfo() 이렇게 가져오던 정보 viewModel에 유저정보를 옵저빙하는 방식으로 변경

MyPageViewModel 전부 수정해보려 했지만 부피가 너무 커서 중간에 한번 합치고 남은 작업들은 세분화해서 작업하는 것이 나을거라 생각했습니다. 

작업 예정
1. Badge ViewModel 분리
2. BadgePage로 넘기는 방식 (현재는 MyPageViewModel에서 리스트를 불러오고 화면이동해서 그 데이터를 가져오는 방식인데 이동시키고 api호출하는 방식으로 바꾸려 합니다.)
3. EssayDetail로 이동시키는 방식도 수정하려 합니다. 