### PR TITLE
[Refactor] BadgeViewModel 분리

### DIFF
--- a/app/src/main/java/com/echoist/linkedout/data/ExampleItems.kt
+++ b/app/src/main/java/com/echoist/linkedout/data/ExampleItems.kt
@@ -6,38 +6,24 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import com.echoist.linkedout.PRIVATE_POPUP_URL
-import com.echoist.linkedout.R
 import com.echoist.linkedout.api.EssayApi
 import java.util.Stack
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class ExampleItems @Inject constructor(){
+class ExampleItems @Inject constructor() {
 
     var detailEssayBackStack = Stack<EssayApi.EssayItem>()
 
-    var storageEssay by mutableStateOf(EssayApi.EssayItem("",""))
-
-
-    private var exampleBadge by mutableStateOf(
-        BadgeBoxItem(R.drawable.badge_love,"love","emotion",1,5)
-    )
-    var simpleBadgeList : SnapshotStateList<BadgeBoxItem> = mutableStateListOf(
-        exampleBadge,exampleBadge,exampleBadge,exampleBadge,exampleBadge
-    )
-
-    var exampleDetailBadge by mutableStateOf(
-        BadgeBoxItemWithTag(0,"","",1, tags = listOf("1","2"), exp = 0, level = 1)
-    )
-    var detailBadgeList : SnapshotStateList<BadgeBoxItemWithTag> = mutableStateListOf(exampleDetailBadge)
+    var storageEssay by mutableStateOf(EssayApi.EssayItem("", ""))
 
     var exampleStroy by mutableStateOf(
-        Story(2,"","20240605",2)
+        Story(2, "", "20240605", 2)
     )
 
-    var storyList : SnapshotStateList<Story> = mutableStateListOf(exampleStroy,exampleStroy,exampleStroy,exampleStroy,exampleStroy)
-
+    var storyList: SnapshotStateList<Story> =
+        mutableStateListOf(exampleStroy, exampleStroy, exampleStroy, exampleStroy, exampleStroy)
 
     /**
      * MyLogPage items
@@ -47,11 +33,10 @@ class ExampleItems @Inject constructor(){
     var myEssayList by mutableStateOf(mutableStateListOf<EssayApi.EssayItem>())
     var publishedEssayList by mutableStateOf(mutableStateListOf<EssayApi.EssayItem>())
 
-
     var detailEssay by mutableStateOf(
         EssayApi.EssayItem(
             id = 0,
-            author = UserInfo(1,"groove"),
+            author = UserInfo(1, "groove"),
             content = "이 에세이는 예시입니다.123123이 에세이는 예시입니다.123123이 에세이는 예시입니다.123123이 에세이는 예시입니다.123123",
             createdDate = "2024년 04월 28일 16:47",
             linkedOutGauge = 5,
@@ -59,7 +44,7 @@ class ExampleItems @Inject constructor(){
             thumbnail = "http 값 있어요~",
             title = "예시 에세이",
             updatedDate = "2024-05-15",
-            tags = listOf(EssayApi.Tag(1,"tag"), EssayApi.Tag(1,"tag"))
+            tags = listOf(EssayApi.Tag(1, "tag"), EssayApi.Tag(1, "tag"))
         )
     )
     var userItem by mutableStateOf(
@@ -81,11 +66,9 @@ class ExampleItems @Inject constructor(){
             password = "1234",
             gender = "male",
             birthDate = "0725",
-            essayStats = EssayStats(0,0,0)
+            essayStats = EssayStats(0, 0, 0)
         )
     )
-
-
 
     var subscribeUserList = mutableStateListOf( //구독유저 리스트 api통신해서 받을것.
         userItem.copy(id = 1, nickname = "꾸르륵"),
@@ -99,15 +82,17 @@ class ExampleItems @Inject constructor(){
 
     var exampleEmptyEssayList = emptyList<EssayApi.EssayItem>()
 
-
-    var randomList : SnapshotStateList<EssayApi.EssayItem> = mutableStateListOf(detailEssay,detailEssay,detailEssay,detailEssay)
-    var followingList : SnapshotStateList<EssayApi.EssayItem> = mutableStateListOf(detailEssay)
-    var firstSentences : SnapshotStateList<EssayApi.EssayItem> = mutableStateListOf(detailEssay,detailEssay,detailEssay,detailEssay,detailEssay)
-    var lastSentences : SnapshotStateList<EssayApi.EssayItem> = mutableStateListOf(detailEssay,detailEssay,detailEssay,detailEssay,detailEssay)
-    var previousEssayList: SnapshotStateList<EssayApi.EssayItem> =  mutableStateListOf(detailEssay,detailEssay,detailEssay,detailEssay,detailEssay)
-    var recentViewedEssayList: SnapshotStateList<EssayApi.EssayItem> =  mutableStateListOf(EssayApi.EssayItem(title = "최근 본 글이 없습니다.", content = "empty"))
-    var storageEssayList : SnapshotStateList<EssayApi.EssayItem> = mutableStateListOf(detailEssay,detailEssay,detailEssay,detailEssay)
-
-
-
+    var randomList: SnapshotStateList<EssayApi.EssayItem> =
+        mutableStateListOf(detailEssay, detailEssay, detailEssay, detailEssay)
+    var followingList: SnapshotStateList<EssayApi.EssayItem> = mutableStateListOf(detailEssay)
+    var firstSentences: SnapshotStateList<EssayApi.EssayItem> =
+        mutableStateListOf(detailEssay, detailEssay, detailEssay, detailEssay, detailEssay)
+    var lastSentences: SnapshotStateList<EssayApi.EssayItem> =
+        mutableStateListOf(detailEssay, detailEssay, detailEssay, detailEssay, detailEssay)
+    var previousEssayList: SnapshotStateList<EssayApi.EssayItem> =
+        mutableStateListOf(detailEssay, detailEssay, detailEssay, detailEssay, detailEssay)
+    var recentViewedEssayList: SnapshotStateList<EssayApi.EssayItem> =
+        mutableStateListOf(EssayApi.EssayItem(title = "최근 본 글이 없습니다.", content = "empty"))
+    var storageEssayList: SnapshotStateList<EssayApi.EssayItem> =
+        mutableStateListOf(detailEssay, detailEssay, detailEssay, detailEssay)
 }

--- a/app/src/main/java/com/echoist/linkedout/navigation/MobileApp.kt
+++ b/app/src/main/java/com/echoist/linkedout/navigation/MobileApp.kt
@@ -76,7 +76,6 @@ fun MobileApp(
     val signUpViewModel: SignUpViewModel = hiltViewModel()
     val myLogViewModel: MyLogViewModel = hiltViewModel()
     val communityViewModel: CommunityViewModel = hiltViewModel()
-    val settingsViewModel: MyPageViewModel = hiltViewModel()
     val supportViewModel: SupportViewModel = hiltViewModel()
 
     NavHost(
@@ -259,7 +258,7 @@ fun MobileApp(
             AccountWithdrawalPage(navController)
         }
         composable(Routes.BadgePage) {
-            BadgePage(navController, settingsViewModel)
+            BadgePage(navController)
         }
         composable(
             Routes.WritingPage,

--- a/app/src/main/java/com/echoist/linkedout/page/home/HomePage.kt
+++ b/app/src/main/java/com/echoist/linkedout/page/home/HomePage.kt
@@ -329,7 +329,7 @@ fun ModalBottomSheetContent(viewModel: HomeViewModel, navController: NavControll
                 isLogoutClicked = false
                 navController.navigate(Routes.LoginPage) {
                     // 기존의 모든 백스택을 제거하고 login 루트로 설정
-                    popUpTo(navController.graph.startDestinationId) { inclusive = true }
+                    popUpTo(Routes.LoginPage) { inclusive = true }
                     launchSingleTop = true
                 }
                 //로컬 자동로그인, id pw 값 초기화

--- a/app/src/main/java/com/echoist/linkedout/presentation/TabletBadgeScreen.kt
+++ b/app/src/main/java/com/echoist/linkedout/presentation/TabletBadgeScreen.kt
@@ -14,29 +14,33 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.echoist.linkedout.page.settings.BadgeItem
+import com.echoist.linkedout.viewModels.BadgeViewModel
 import com.echoist.linkedout.viewModels.MyPageViewModel
 
 @Composable
 fun TabletBadgeRoute(
     contentPadding: PaddingValues,
-    viewModel: MyPageViewModel = hiltViewModel()
+    viewModel: BadgeViewModel = hiltViewModel()
 ) {
     val hasCalledApi = remember { mutableStateOf(false) }
-    val badgeBoxItems = viewModel.getDetailBadgeList()
 
     if (!hasCalledApi.value) {
         hasCalledApi.value = true
     }
+    /*
+        Column(
+            Modifier
+                .verticalScroll(rememberScrollState())
+                .padding(contentPadding)
+                .padding(horizontal = 20.dp)
+        ) {
+            badgeBoxItems.forEach {
+                BadgeItem(it, viewModel) {
 
-    Column(
-        Modifier
-            .verticalScroll(rememberScrollState())
-            .padding(contentPadding)
-            .padding(horizontal = 20.dp)
-    ) {
-        badgeBoxItems.forEach {
-            BadgeItem(it, viewModel)
-            Spacer(modifier = Modifier.height(10.dp))
+                }
+                Spacer(modifier = Modifier.height(10.dp))
+            }
         }
-    }
+
+     */
 }

--- a/app/src/main/java/com/echoist/linkedout/presentation/TabletMyInfoScreen.kt
+++ b/app/src/main/java/com/echoist/linkedout/presentation/TabletMyInfoScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.material3.SheetValue
 import androidx.compose.material3.rememberStandardBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -29,6 +30,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
+import com.echoist.linkedout.Routes
 import com.echoist.linkedout.page.settings.BadgeDescriptionBox
 import com.echoist.linkedout.page.settings.LinkedOutBadgeGrid
 import com.echoist.linkedout.page.settings.MembershipSettingBar
@@ -50,6 +52,9 @@ fun TabletMyInfoRoute(
     var isApiFinished by remember {
         mutableStateOf(false)
     }
+
+    val badgeList by viewModel.badgeList.collectAsState()
+
     LaunchedEffect(key1 = isApiFinished) {
         viewModel.requestMyInfo()
         viewModel.readSimpleBadgeList()
@@ -137,8 +142,11 @@ fun TabletMyInfoRoute(
                 }
             }
             if (viewModel.isApiFinished) {
-                SettingBar("링크드아웃 배지") { viewModel.readDetailBadgeList(navController) }
-                LinkedOutBadgeGrid(viewModel)
+                SettingBar("링크드아웃 배지") { navController.navigate(Routes.BadgePage) }
+                LinkedOutBadgeGrid(badgeList) {
+                    viewModel.badgeBoxItem = it
+                    viewModel.isBadgeClicked = true
+                }
                 SettingBar("최근 본 글") { navController.navigate("RecentViewedEssayPage") }
                 RecentEssayList(
                     itemList = viewModel.getRecentViewedEssayList(),
@@ -156,7 +164,9 @@ fun TabletMyInfoRoute(
                 modifier = Modifier.fillMaxSize(),
                 contentAlignment = Alignment.Center
             ) {
-                BadgeDescriptionBox(viewModel.badgeBoxItem!!, viewModel)
+                BadgeDescriptionBox(viewModel.badgeBoxItem!!) {
+                    viewModel.isBadgeClicked = false
+                }
             }
         }
     }

--- a/app/src/main/java/com/echoist/linkedout/viewModels/BadgeViewModel.kt
+++ b/app/src/main/java/com/echoist/linkedout/viewModels/BadgeViewModel.kt
@@ -1,0 +1,76 @@
+package com.echoist.linkedout.viewModels
+
+import android.content.ContentValues
+import android.util.Log
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.echoist.linkedout.api.UserApi
+import com.echoist.linkedout.data.BadgeBoxItemWithTag
+import com.echoist.linkedout.data.toBadgeBoxItem
+import com.echoist.linkedout.page.myLog.Token
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class BadgeViewModel @Inject constructor(
+    private val userApi: UserApi
+) : ViewModel() {
+
+    private val _badgeList = MutableStateFlow<List<BadgeBoxItemWithTag>>(emptyList())
+    val badgeList: StateFlow<List<BadgeBoxItemWithTag>> = _badgeList
+
+    var isLevelUpSuccess by mutableStateOf(false)
+    var levelUpBadgeItem: BadgeBoxItemWithTag? by mutableStateOf(null)
+
+    init {
+        loadBadgeList()
+    }
+
+    private fun loadBadgeList() {
+        viewModelScope.launch {
+            try {
+                val response = userApi.readBadgeWithTagsList()
+                response.body()?.data?.badges?.let { badges ->
+                    _badgeList.value = badges.map { it.toBadgeBoxItem() }
+                }
+                Token.accessToken = response.headers()["x-access-token"]?.takeIf { it.isNotEmpty() }
+                    ?: Token.accessToken
+            } catch (e: Exception) {
+                e.printStackTrace()
+                // API 요청 실패
+                Log.e("writeEssayApiFailed", "Failed to write essay: ${e.message}")
+            }
+        }
+    }
+
+    fun requestBadgeLevelUp(badgeItem: BadgeBoxItemWithTag) {
+        viewModelScope.launch {
+            try {
+                val response = userApi.requestBadgeLevelUp(badgeItem.badgeId!!)
+                Log.d(ContentValues.TAG, "requestBadgeLevelUp: ${Token.accessToken}")
+
+                Token.accessToken = response.headers()["x-access-token"]?.takeIf { it.isNotEmpty() }
+                    ?: Token.accessToken
+
+                if (response.body()!!.success) {
+                    isLevelUpSuccess = true
+                    levelUpBadgeItem = badgeItem
+                    delay(1000)
+                    isLevelUpSuccess = false
+                    levelUpBadgeItem = null
+                }
+            } catch (e: Exception) {
+                e.printStackTrace()
+                // api 요청 실패
+                Log.e("writeEssayApiFailed", "Failed to write essay: ${e.message}")
+            }
+        }
+    }
+}


### PR DESCRIPTION
1. MyPageViewModel에서 BadgeViewModel 분리
2. MyPage, BadgePage 뱃지 관련 ViewModel 파라미터 제거
3. 기존 전역으로 가지고 있던 뱃지 리스트, 뱃지 디테일 리스트 사용 -> viewModel에서 가지고 있고 뷰에서는 옵저빙하는 방식으로 변경
4. 로그아웃 시 로그인 제외 스택 제거