### PR TITLE
Fix : Reauthentication 재로그인 버그수정

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -31,7 +31,20 @@
         <State />
       </entry>
       <entry key="app">
-        <State />
+        <State>
+          <targetSelectedWithDropDown>
+            <Target>
+              <type value="QUICK_BOOT_TARGET" />
+              <deviceKey>
+                <Key>
+                  <type value="VIRTUAL_DEVICE_PATH" />
+                  <value value="$USER_HOME$/.android/avd/Client_Test.avd" />
+                </Key>
+              </deviceKey>
+            </Target>
+          </targetSelectedWithDropDown>
+          <timeTargetWasSelectedWithDropDown value="2024-09-11T09:22:10.049291Z" />
+        </State>
       </entry>
     </value>
   </component>

--- a/app/src/main/java/com/echoist/linkedout/Extensions.kt
+++ b/app/src/main/java/com/echoist/linkedout/Extensions.kt
@@ -1,7 +1,13 @@
 package com.echoist.linkedout
 
 import android.util.Patterns
+import androidx.navigation.NavController
 
 fun String.isEmailValid(): Boolean {
     return Patterns.EMAIL_ADDRESS.matcher(this).matches()
+}
+
+fun getCurrentRoute(navController: NavController): String? {
+    // 현재 BackStackEntry를 가져와서 경로를 반환
+    return navController.currentBackStackEntry?.destination?.route
 }

--- a/app/src/main/java/com/echoist/linkedout/MainActivity.kt
+++ b/app/src/main/java/com/echoist/linkedout/MainActivity.kt
@@ -29,7 +29,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.compose.rememberNavController
 import com.echoist.linkedout.components.ExitAppErrorBox
 import com.echoist.linkedout.navigation.MobileApp
-import com.echoist.linkedout.page.home.ReLogInWaringBox
+import com.echoist.linkedout.page.home.ReLogInWaringAlert
 import com.echoist.linkedout.page.myLog.Token
 import com.echoist.linkedout.presentation.TabletApp
 import com.echoist.linkedout.ui.theme.LinkedOutTheme
@@ -139,7 +139,7 @@ import kotlinx.coroutines.delay
                         .fillMaxSize()
                         .clickable(enabled = false) { }
                         .background(Color.Black.copy(0.7f)), contentAlignment = Alignment.Center) {
-                        ReLogInWaringBox {
+                        ReLogInWaringAlert {
                             navigateWithClearBackStack(navController, Routes.LoginPage)
                             homeViewModel.setReAuthenticationRequired(false)
                         }

--- a/app/src/main/java/com/echoist/linkedout/MainActivity.kt
+++ b/app/src/main/java/com/echoist/linkedout/MainActivity.kt
@@ -134,7 +134,12 @@ import kotlinx.coroutines.delay
                     ) { ExitAppErrorBox() }
                 }
 
-                if (isReAuthenticationRequired) {
+                val currentRoute = getCurrentRoute(navController)
+
+                //온보딩,로그인 화면 에서는 401에도 재 로그인 ui 표시 x
+                if (isReAuthenticationRequired &&
+                    currentRoute != Routes.OnBoarding && currentRoute != Routes.LoginPage) {
+
                     Box(modifier = Modifier
                         .fillMaxSize()
                         .clickable(enabled = false) { }

--- a/app/src/main/java/com/echoist/linkedout/page/home/HomePage.kt
+++ b/app/src/main/java/com/echoist/linkedout/page/home/HomePage.kt
@@ -272,7 +272,7 @@ fun HomePage(
                 .background(Color.Black.copy(0.7f)), contentAlignment = Alignment.Center
         )
         {
-            Notice_Main(isClickedClose = {
+            NoticeAlert(isClickedClose = {
                 viewModel.latestNoticeId = null
             }, isClickedOpened = {
                 viewModel.requestDetailNotice(viewModel.latestNoticeId!!, navController)
@@ -1232,12 +1232,12 @@ fun ReactivateOrDeleteBox(isClickedReActivate: () -> Unit, isClickedDeActivate: 
 
 @OptIn(ExperimentalGlideComposeApi::class)
 @Composable
-fun Notice_Main(isClickedClose: () -> Unit, isClickedOpened: () -> Unit) {
+fun NoticeAlert(isClickedClose: () -> Unit, isClickedOpened: () -> Unit) {
 
     Box(
         modifier = Modifier
             .width(280.dp)
-            .height(411.dp)
+            .height(203.dp)
             .background(color = Color(0xFF121212), shape = RoundedCornerShape(size = 10.dp)),
         contentAlignment = Alignment.Center
     ) {
@@ -1254,15 +1254,7 @@ fun Notice_Main(isClickedClose: () -> Unit, isClickedOpened: () -> Unit) {
                     textAlign = TextAlign.Center,
                 )
             )
-            Spacer(modifier = Modifier.height(6.dp))
-            Text(
-                text = "자세히 보기를 눌러 공지를 확인하세요.",
-                textAlign = TextAlign.Center,
-                color = Color.White,
-                modifier = Modifier
-                    .height(240.dp)
-                    .verticalScroll(rememberScrollState())
-            )
+            Spacer(modifier = Modifier.height(39.dp))
             Row {
                 Button(
                     onClick = { isClickedOpened() },
@@ -1291,7 +1283,7 @@ fun Notice_Main(isClickedClose: () -> Unit, isClickedOpened: () -> Unit) {
 }
 
 @Composable
-fun ReLogInWaringBox(isClicked: () -> Unit) {
+fun ReLogInWaringAlert(isClicked: () -> Unit) {
     Box(
         modifier = Modifier
             .fillMaxWidth()

--- a/app/src/main/java/com/echoist/linkedout/page/home/HomePage.kt
+++ b/app/src/main/java/com/echoist/linkedout/page/home/HomePage.kt
@@ -275,7 +275,7 @@ fun HomePage(
             NoticeAlert(isClickedClose = {
                 viewModel.latestNoticeId = null
             }, isClickedOpened = {
-                viewModel.requestDetailNotice(viewModel.latestNoticeId!!, navController)
+                navController.navigate("${Routes.NoticeDetailPage}/${viewModel.latestNoticeId!!}")
             })
         }
     } //토큰 만료시

--- a/app/src/main/java/com/echoist/linkedout/viewModels/HomeViewModel.kt
+++ b/app/src/main/java/com/echoist/linkedout/viewModels/HomeViewModel.kt
@@ -367,23 +367,6 @@ class HomeViewModel @Inject constructor(
             userApi.requestDeleteUser()
         }
     }
-
-    //notice 세부 사항 읽은 후 세부 페이지로 이동
-    fun requestDetailNotice(noticeId: Int, navController: NavController) {
-
-        apiCall(onSuccess =
-        { response ->
-            Log.d("공지사항 디테일 확인", "성공 공지 내용 : ${response.data.content}")
-
-            val moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
-            val jsonAdapter = moshi.adapter(Notice::class.java)
-            val json = jsonAdapter.toJson(response.data)
-            navController.navigate("${Routes.NoticeDetailPage}/$json")
-
-        }) {
-            supportApi.readNoticeDetail(noticeId)
-        }
-    }
 }
 
 

--- a/app/src/main/java/com/echoist/linkedout/viewModels/SocialLoginViewModel.kt
+++ b/app/src/main/java/com/echoist/linkedout/viewModels/SocialLoginViewModel.kt
@@ -11,11 +11,6 @@ import android.os.Bundle
 import android.util.Log
 import androidx.activity.compose.ManagedActivityResultLauncher
 import androidx.activity.result.ActivityResult
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Button
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -26,6 +21,7 @@ import androidx.navigation.NavController
 import com.echoist.linkedout.BuildConfig
 import com.echoist.linkedout.Routes
 import com.echoist.linkedout.SharedPreferencesUtil
+import com.echoist.linkedout.TokenRepository
 import com.echoist.linkedout.api.NaverApiService
 import com.echoist.linkedout.api.SignUpApi
 import com.echoist.linkedout.api.SocialSignUpApi
@@ -65,7 +61,8 @@ class SocialLoginViewModel @Inject constructor(
     private val exampleItems: ExampleItems,
     private val signUpApi: SignUpApi,
     private val socialSignUpApi: SocialSignUpApi,
-    private val supportApi: SupportApi
+    private val supportApi: SupportApi,
+    private val tokenRepository: TokenRepository
 ) : ViewModel() {
     private val auth: FirebaseAuth = Firebase.auth
 
@@ -133,6 +130,7 @@ class SocialLoginViewModel @Inject constructor(
 
                     loginStatusCode = response.code()
                     navController.popBackStack("OnBoarding", false) //onboarding까지 전부 삭제.
+                    tokenRepository.setReAuthenticationRequired(false)
 
                     when{
                         //자동로그인 클릭 + 로그인 성공 시 엑세스토큰, 리프레시토큰 저장 + 토큰의 30일 이후 날짜 계산
@@ -530,6 +528,7 @@ class SocialLoginViewModel @Inject constructor(
 
                     Token.accessToken = accessToken
                     Token.refreshToken = refreshToken
+                    tokenRepository.setReAuthenticationRequired(false)
 
                     Log.i("server header access token($loginType)", accessToken)
                     Log.i("server refresh token($loginType)", refreshToken)
@@ -549,7 +548,6 @@ class SocialLoginViewModel @Inject constructor(
                     loginStatusCode = response.code()
                     Log.e("$loginType 서버와 api", "Failed ${response.code()}")
                 }
-
             } catch (e: Exception) {
                 // API 요청 실패
                 e.printStackTrace()
@@ -557,19 +555,4 @@ class SocialLoginViewModel @Inject constructor(
             }
         }
     }
-
-
-}
-
-@Composable
-fun LoginSuccessDialog(successMsg: String, dialogState: MutableState<Boolean>) {
-    AlertDialog(
-        onDismissRequest = { dialogState.value = false },
-        confirmButton = {
-            Button(onClick = { dialogState.value = false }) {
-                Text(text = "확인")
-            }
-        },
-        text = { Text(text = successMsg) },
-    )
 }


### PR DESCRIPTION
- 홈화면의 공지알람 UI 변경 (안에 미리보기가 사용되지않으므로 단순 크기수정)
- 현재 route를 반환하는 함수를 추가
- noticeAlert 클릭시 세부사항을 요청하고 화면이동하던 흐름을 세부페이지로 우선 이동 후 세부사항을 요청하는 흐름으로 변경 
-401 시 재로그인 요청 UI가 로그인화면으로 이동해도 유지되는 버그 수정

1. 홈화면&온보딩에선 재로그인 요청UI를 띄우지 않습니다.
2. 로그인 화면에서도 api 401응답시 reAuthentication이 true로 설정되기 때문에 소셜 로그인&로그인 성공 시 reAuthentication 변수를 false로 설정합니다.
