### PR TITLE
feat: viewModel HomeScreen상위컴포넌트에서 전달

### DIFF
--- a/app/src/main/java/com/echoist/linkedout/MainActivity.kt
+++ b/app/src/main/java/com/echoist/linkedout/MainActivity.kt
@@ -109,7 +109,6 @@ class MainActivity : ComponentActivity() {
                 }
 
                 val currentRoute = getCurrentRoute(navController)
-
                 //온보딩,로그인 화면 에서는 401에도 재 로그인 ui 표시 x
                 if (isReAuthenticationRequired &&
                     currentRoute != Routes.OnBoarding && currentRoute != Routes.LoginPage

--- a/app/src/main/java/com/echoist/linkedout/navigation/MobileApp.kt
+++ b/app/src/main/java/com/echoist/linkedout/navigation/MobileApp.kt
@@ -23,6 +23,7 @@ import com.echoist.linkedout.presentation.essay.write.WritingCompletePage
 import com.echoist.linkedout.presentation.essay.write.WritingPage
 import com.echoist.linkedout.presentation.essay.write.WritingViewModel
 import com.echoist.linkedout.presentation.home.HomePage
+import com.echoist.linkedout.presentation.home.HomeViewModel
 import com.echoist.linkedout.presentation.home.drawable.setting.NotificationSettingScreen
 import com.echoist.linkedout.presentation.home.drawable.support.SupportScreen
 import com.echoist.linkedout.presentation.home.drawable.support.SupportViewModel
@@ -73,6 +74,7 @@ fun MobileApp(
     val signUpViewModel: SignUpViewModel = hiltViewModel()
     val myLogViewModel: MyLogViewModel = hiltViewModel()
     val communityViewModel: CommunityViewModel = hiltViewModel()
+    val homeViewModel: HomeViewModel = hiltViewModel()
     val supportViewModel: SupportViewModel = hiltViewModel()
 
     NavHost(
@@ -102,7 +104,7 @@ fun MobileApp(
         ) { backStackEntry ->
             val statusCode =
                 backStackEntry.arguments?.getInt("statusCode") ?: 200
-            HomePage(navController, writingViewModel = writingViewModel, statusCode = statusCode)
+            HomePage(navController, homeViewModel, writingViewModel = writingViewModel, statusCode = statusCode)
         }
         composable(Routes.ThemeModeScreen) {
             ThemeModeScreen(navController)

--- a/app/src/main/java/com/echoist/linkedout/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/echoist/linkedout/presentation/home/HomeScreen.kt
@@ -294,6 +294,7 @@ fun HomePage(
         }
     }
 }
+
 @Composable
 fun WriteFTB(
     navController: NavController,
@@ -683,7 +684,6 @@ fun LogoutBox(isCancelClicked: () -> Unit, isLogoutClicked: () -> Unit) {
         }
     }
 }
-
 
 
 @OptIn(ExperimentalGlideComposeApi::class)


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #81 

## 📝작업 내용

>글로키 다이얼로그 앱 시작 후 한번만 뜨도록 설정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

>hiltViewModel로 생성하게 되는 경우에는 ViewModelStoreOwner가 backstackentry가 되어서 스택이 쌓일때마다 viewModel 인스턴스가 새로 생성이 되어서 false로 바꿔도 새로운 인스턴스에는 true이기 때문에 글로키가 계속 떴던 것 같습니다. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an exit confirmation prompt to enhance user experience when exiting the app.
	- Added a Floating Action Button (FAB) for quick navigation to the writing page.
	- Enhanced user status management to handle deactivated and banned users.
	- Improved UI elements, including a background image and visibility toggles for components.

- **Bug Fixes**
	- Refined rendering logic for alerts to prevent unnecessary prompts during critical navigation states.

- **Documentation**
	- Updated navigation logic and component interactions for clarity and improved user flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->