### PR TITLE
Refactor/home view model

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -2,32 +2,7 @@
 <project version="4">
   <component name="deploymentTargetDropDown">
     <value>
-      <entry key="Authentication_6_BottomModal">
-        <State />
-      </entry>
-      <entry key="Notice_Main">
-        <State>
-          <runningDeviceTargetSelectedWithDropDown>
-            <Target>
-              <type value="RUNNING_DEVICE_TARGET" />
-              <deviceKey>
-                <Key>
-                  <type value="VIRTUAL_DEVICE_PATH" />
-                  <value value="$USER_HOME$/.android/avd/Client_Test.avd" />
-                </Key>
-              </deviceKey>
-            </Target>
-          </runningDeviceTargetSelectedWithDropDown>
-          <timeTargetWasSelectedWithDropDown value="2024-08-11T12:33:07.305734Z" />
-        </State>
-      </entry>
-      <entry key="ProvisionsWebv2iew">
-        <State />
-      </entry>
-      <entry key="ProvisionsWebview">
-        <State />
-      </entry>
-      <entry key="StoryCountIcon">
+      <entry key="UITestSample">
         <State />
       </entry>
       <entry key="app">

--- a/app/src/main/java/com/echoist/linkedout/data/di/ApiModule.kt
+++ b/app/src/main/java/com/echoist/linkedout/data/di/ApiModule.kt
@@ -9,6 +9,7 @@ import com.echoist.linkedout.data.api.SocialSignUpApi
 import com.echoist.linkedout.data.api.StoryApi
 import com.echoist.linkedout.data.api.SupportApi
 import com.echoist.linkedout.data.api.UserApi
+import com.echoist.linkedout.data.dto.ExampleItems
 import com.echoist.linkedout.data.repository.TokenRepository
 import com.echoist.linkedout.presentation.util.BASE_URL
 import com.squareup.moshi.Moshi
@@ -48,6 +49,7 @@ object ApiModule {
             .build()
     }
 
+
     @Provides
     @Singleton
     fun provideErrorHandlingInterceptor(tokenRepository: TokenRepository): ErrorHandlingInterceptor {
@@ -58,6 +60,11 @@ object ApiModule {
     @Singleton
     fun provideApiClient(retrofit: Retrofit): EssayApi {
         return retrofit.create(EssayApi::class.java)
+    }
+    @Provides
+    @Singleton
+    fun provideExampleItemsClient(): ExampleItems {
+        return ExampleItems()
     }
 
     @Provides

--- a/app/src/main/java/com/echoist/linkedout/data/repository/UserDataRepository.kt
+++ b/app/src/main/java/com/echoist/linkedout/data/repository/UserDataRepository.kt
@@ -2,16 +2,29 @@ package com.echoist.linkedout.data.repository
 
 import android.content.SharedPreferences
 import com.echoist.linkedout.data.dto.Tokens
+import com.echoist.linkedout.data.dto.UserInfo
 import com.echoist.linkedout.presentation.home.drawable.setting.TimeSelectionIndex
 import com.echoist.linkedout.presentation.util.DISPLAY_INFO
 import com.echoist.linkedout.presentation.util.KEY_HOUR_INDEX
 import com.echoist.linkedout.presentation.util.KEY_MINUTE_INDEX
 import com.echoist.linkedout.presentation.util.KEY_PERIOD_INDEX
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Inject
+import javax.inject.Singleton
 
+@Singleton
 class UserDataRepository @Inject constructor(
     private val sharedPreferences: SharedPreferences
 ) {
+
+    private val _userInfo = MutableStateFlow(UserInfo())
+    val userInfo: StateFlow<UserInfo> = _userInfo
+
+    fun setUserInfo(userInfo: UserInfo){
+        _userInfo.value = userInfo
+    }
+
     fun saveWritingRemindNotification(writingRemindNotification: Boolean) {
         with(sharedPreferences.edit()) {
             putBoolean("writing_notification", writingRemindNotification)

--- a/app/src/main/java/com/echoist/linkedout/presentation/TabletApp.kt
+++ b/app/src/main/java/com/echoist/linkedout/presentation/TabletApp.kt
@@ -40,8 +40,8 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import com.echoist.linkedout.R
-import com.echoist.linkedout.data.api.EssayApi
 import com.echoist.linkedout.navigation.TabletNavHost
+import com.echoist.linkedout.presentation.essay.write.WritingViewModel
 import com.echoist.linkedout.presentation.home.HomeViewModel
 import com.echoist.linkedout.presentation.home.LogoutBox
 import com.echoist.linkedout.presentation.home.MyBottomNavigation
@@ -62,7 +62,8 @@ fun TabletApp(
     homeViewModel: HomeViewModel = hiltViewModel(),
     drawableViewModel: DrawableViewModel = hiltViewModel(),
     myLogViewModel: MyLogViewModel = hiltViewModel(),
-    userInfoViewModel: UserInfoViewModel = hiltViewModel()
+    userInfoViewModel: UserInfoViewModel = hiltViewModel(),
+    writingViewModel: WritingViewModel = hiltViewModel()
 ) {
     val configuration = LocalConfiguration.current
 
@@ -159,8 +160,7 @@ fun TabletApp(
                             ),
                             onClick = {
                                 navController.navigate(Routes.WritingPage)
-                                homeViewModel.initializeDetailEssay()
-                                homeViewModel.setStorageEssay(EssayApi.EssayItem())
+                                writingViewModel.initialize()
                             },
                             shape = RoundedCornerShape(100.dp),
                             containerColor = Color.White
@@ -195,8 +195,8 @@ fun TabletApp(
                 ) {
                     Box(
                         modifier = Modifier
-                                .weight(1f)
-                                .fillMaxHeight()
+                            .weight(1f)
+                            .fillMaxHeight()
                     ) {
                         TabletNavHost(
                             startDestination = startDestination,

--- a/app/src/main/java/com/echoist/linkedout/presentation/TabletApp.kt
+++ b/app/src/main/java/com/echoist/linkedout/presentation/TabletApp.kt
@@ -24,6 +24,8 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -43,6 +45,7 @@ import com.echoist.linkedout.navigation.TabletNavHost
 import com.echoist.linkedout.presentation.home.HomeViewModel
 import com.echoist.linkedout.presentation.home.LogoutBox
 import com.echoist.linkedout.presentation.home.MyBottomNavigation
+import com.echoist.linkedout.presentation.home.drawable.DrawableViewModel
 import com.echoist.linkedout.presentation.home.drawable.TabletDrawableScreen
 import com.echoist.linkedout.presentation.home.notification.TabletNotificationScreen
 import com.echoist.linkedout.presentation.home.tutorial.TabletTutorialScreen
@@ -57,6 +60,7 @@ fun TabletApp(
     navController: NavHostController,
     startDestination: String,
     homeViewModel: HomeViewModel = hiltViewModel(),
+    drawableViewModel: DrawableViewModel = hiltViewModel(),
     myLogViewModel: MyLogViewModel = hiltViewModel(),
     userInfoViewModel: UserInfoViewModel = hiltViewModel()
 ) {
@@ -77,6 +81,12 @@ fun TabletApp(
     var isLogoutClicked by remember { mutableStateOf(false) }
     var isNotificationClicked by remember { mutableStateOf(false) }
 
+    LaunchedEffect(key1 = Unit) {
+        drawableViewModel.requestUserGraphSummary()
+    }
+
+    val essayCount by drawableViewModel.essayCount.collectAsState()
+
     val fillWidthFraction = when (configuration.orientation) {
         Configuration.ORIENTATION_LANDSCAPE -> if (isNotificationClicked) 0.7f else 1f
         else -> if (isNotificationClicked) 0.55f else 1f
@@ -91,8 +101,8 @@ fun TabletApp(
             drawerContent = {
                 TabletDrawableScreen(
                     scrollState = scrollState,
-                    userInfo = homeViewModel.getMyInfo(),
-                    essayCounts = homeViewModel.essayCount,
+                    userInfo = drawableViewModel.getMyInfo(),
+                    essayCounts = essayCount,
                     selectedMenu = selectedMenu,
                     onClickMyInfo = {
                         scope.launch {
@@ -184,8 +194,8 @@ fun TabletApp(
                 ) {
                     Box(
                         modifier = Modifier
-                            .weight(1f)
-                            .fillMaxHeight()
+                                .weight(1f)
+                                .fillMaxHeight()
                     ) {
                         TabletNavHost(
                             startDestination = startDestination,
@@ -197,8 +207,8 @@ fun TabletApp(
                     if (isNotificationClicked) {
                         Box(
                             modifier = Modifier
-                                .fillMaxWidth(1f - fillWidthFraction)
-                                .fillMaxHeight()
+                                    .fillMaxWidth(1f - fillWidthFraction)
+                                    .fillMaxHeight()
                         ) {
                             TabletNotificationScreen(
                                 navController = navController,
@@ -235,8 +245,8 @@ fun TabletApp(
         if (homeViewModel.isFirstUser) { // 첫 회원이라면
             Box(
                 modifier = Modifier
-                    .fillMaxSize()
-                    .background(Color.Black.copy(0.7f))
+                        .fillMaxSize()
+                        .background(Color.Black.copy(0.7f))
             )
             TabletTutorialScreen(
                 isCloseClicked = {

--- a/app/src/main/java/com/echoist/linkedout/presentation/TabletApp.kt
+++ b/app/src/main/java/com/echoist/linkedout/presentation/TabletApp.kt
@@ -86,6 +86,7 @@ fun TabletApp(
     }
 
     val essayCount by drawableViewModel.essayCount.collectAsState()
+    val myInfo by homeViewModel.getMyInfo().collectAsState()
 
     val fillWidthFraction = when (configuration.orientation) {
         Configuration.ORIENTATION_LANDSCAPE -> if (isNotificationClicked) 0.7f else 1f
@@ -101,7 +102,7 @@ fun TabletApp(
             drawerContent = {
                 TabletDrawableScreen(
                     scrollState = scrollState,
-                    userInfo = drawableViewModel.getMyInfo(),
+                    userInfo = myInfo,
                     essayCounts = essayCount,
                     selectedMenu = selectedMenu,
                     onClickMyInfo = {

--- a/app/src/main/java/com/echoist/linkedout/presentation/essay/write/WritingViewModel.kt
+++ b/app/src/main/java/com/echoist/linkedout/presentation/essay/write/WritingViewModel.kt
@@ -185,6 +185,8 @@ class WritingViewModel @Inject constructor(
         isTextFeatOpened.value = false
         essayPrimaryId = null
         hint = "10자 이상의 내용을 입력해 주세요"
+        exampleItems.detailEssay = EssayApi.EssayItem()
+        exampleItems.storageEssay = EssayApi.EssayItem()
     }
 
 

--- a/app/src/main/java/com/echoist/linkedout/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/echoist/linkedout/presentation/home/HomeScreen.kt
@@ -73,7 +73,6 @@ import androidx.navigation.compose.rememberNavController
 import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
 import com.bumptech.glide.integration.compose.GlideImage
 import com.echoist.linkedout.R
-import com.echoist.linkedout.data.api.EssayApi
 import com.echoist.linkedout.data.dto.BottomNavItem
 import com.echoist.linkedout.data.dto.UserInfo
 import com.echoist.linkedout.presentation.essay.write.Token
@@ -162,7 +161,7 @@ fun HomePage(
                 }
             },
             bottomBar = { MyBottomNavigation(navController) },
-            floatingActionButton = { WriteFTB(navController, viewModel, writingViewModel) },
+            floatingActionButton = { WriteFTB(navController, writingViewModel) },
             content = {
                 Column(modifier = Modifier.padding(it)) {
 
@@ -296,7 +295,6 @@ fun HomePage(
 @Composable
 fun WriteFTB(
     navController: NavController,
-    viewModel: HomeViewModel = hiltViewModel(),
     writingViewModel: WritingViewModel = hiltViewModel()
 ) {
 
@@ -304,8 +302,6 @@ fun WriteFTB(
         modifier = Modifier.padding(end = 25.dp, bottom = 25.dp),
         onClick = {
             navController.navigate("WritingPage")
-            viewModel.initializeDetailEssay()
-            viewModel.setStorageEssay(EssayApi.EssayItem())
             writingViewModel.isModifyClicked = false
             writingViewModel.initialize()
         },

--- a/app/src/main/java/com/echoist/linkedout/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/echoist/linkedout/presentation/home/HomeScreen.kt
@@ -126,7 +126,6 @@ fun HomePage(
 
     LaunchedEffect(key1 = Unit) {
         viewModel.requestMyInfo()
-        viewModel.requestUserGraphSummary()
         viewModel.requestGuleRoquis()
         viewModel.requestUnreadAlerts()
         viewModel.requestLatestNotice()
@@ -144,7 +143,7 @@ fun HomePage(
     ModalNavigationDrawer(
         drawerState = drawerState,
         drawerContent = {
-            DrawableScreen(viewModel = viewModel, navController)
+            DrawableScreen(navController = navController)
         },
     ) {
         Scaffold(

--- a/app/src/main/java/com/echoist/linkedout/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/echoist/linkedout/presentation/home/HomeViewModel.kt
@@ -28,6 +28,7 @@ import com.echoist.linkedout.data.dto.Release
 import com.echoist.linkedout.data.dto.UserInfo
 import com.echoist.linkedout.data.repository.HomeRepository
 import com.echoist.linkedout.data.repository.TokenRepository
+import com.echoist.linkedout.data.repository.UserDataRepository
 import com.echoist.linkedout.presentation.essay.write.Token
 import com.google.firebase.messaging.FirebaseMessaging
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -42,6 +43,7 @@ import javax.inject.Inject
 @HiltViewModel
 class HomeViewModel @Inject constructor(
     private val exampleItems: ExampleItems,
+    private val userDataRepository: UserDataRepository,
     private val userApi: UserApi,
     private val supportApi: SupportApi,
     private val homeRepository: HomeRepository,
@@ -105,6 +107,12 @@ class HomeViewModel @Inject constructor(
             Log.d("헤더 토큰", Token.accessToken)
             exampleItems.myProfile = response.data.user
             exampleItems.myProfile.essayStats = response.data.essayStats
+
+            val userinfo = response.data.user.apply {
+                essayStats = response.data.essayStats
+            }
+
+            userDataRepository.setUserInfo(userinfo)
             Log.i(TAG, "readMyInfo: ${exampleItems.myProfile}")
             locationNotification = exampleItems.myProfile.locationConsent ?: false
 
@@ -117,8 +125,8 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    fun getMyInfo(): UserInfo { // 함수 이름 변경
-        return exampleItems.myProfile
+    fun getMyInfo(): StateFlow<UserInfo> { // 함수 이름 변경
+        return userDataRepository.userInfo
     }
 
     //고유식별자

--- a/app/src/main/java/com/echoist/linkedout/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/echoist/linkedout/presentation/home/HomeViewModel.kt
@@ -1,11 +1,7 @@
 package com.echoist.linkedout.presentation.home
 
-import android.annotation.SuppressLint
-import android.app.AlarmManager
-import android.app.PendingIntent
 import android.content.ContentValues.TAG
 import android.content.Context
-import android.content.Intent
 import android.util.Log
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
@@ -15,14 +11,12 @@ import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.runtime.toMutableStateList
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.echoist.linkedout.AlarmReceiver
 import com.echoist.linkedout.data.api.EssayApi
 import com.echoist.linkedout.data.api.SignUpApiImpl
 import com.echoist.linkedout.data.api.SupportApi
 import com.echoist.linkedout.data.api.UserApi
 import com.echoist.linkedout.data.api.apiCall
 import com.echoist.linkedout.data.dto.ExampleItems
-import com.echoist.linkedout.data.dto.NotificationSettings
 import com.echoist.linkedout.data.dto.Release
 import com.echoist.linkedout.data.dto.UserInfo
 import com.echoist.linkedout.data.repository.HomeRepository
@@ -34,9 +28,6 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
-import java.text.SimpleDateFormat
-import java.util.Calendar
-import java.util.Locale
 import javax.inject.Inject
 
 @HiltViewModel
@@ -51,11 +42,6 @@ class HomeViewModel @Inject constructor(
 
     var myProfile by mutableStateOf(exampleItems.myProfile)
 
-    var viewedNotification by mutableStateOf(false)
-    var reportNotification by mutableStateOf(false)
-    var marketingNotification by mutableStateOf(false)
-    var locationNotification by mutableStateOf(false)
-
     var isLoading by mutableStateOf(false)
     var isFirstUser by mutableStateOf(false)
     var latestNoticeId: Int? by mutableStateOf(null) //공지가 있을경우 true, 없을경우 Null
@@ -68,8 +54,6 @@ class HomeViewModel @Inject constructor(
     private val _isUserDeleteApiFinished = MutableStateFlow(false)
     val isUserDeleteApiFinished: StateFlow<Boolean> = _isUserDeleteApiFinished
     private val _isUpdateUserNotificationApiFinished = MutableStateFlow(false)
-    val isUpdateUserNotificationApiFinished: StateFlow<Boolean> =
-        _isUpdateUserNotificationApiFinished
 
     private val _isExistLatestUpdate = MutableStateFlow(false)
     val isExistLatestUpdate: StateFlow<Boolean> = _isExistLatestUpdate
@@ -103,8 +87,6 @@ class HomeViewModel @Inject constructor(
 
             userDataRepository.setUserInfo(userinfo)
             Log.i(TAG, "readMyInfo: ${userDataRepository.userInfo}")
-            locationNotification = userinfo.locationConsent ?: false
-
             //첫유저인지 판별
             isFirstUser = response.data.user.isFirst == true
 
@@ -139,136 +121,6 @@ class HomeViewModel @Inject constructor(
                 //토큰없으면 기기등록도 안됨
             }
         }
-    }
-
-    //사용자 알림설정 get
-    var isApifinished by mutableStateOf(false)
-
-    //HomeRepository 도입
-    fun readUserNotification() {
-
-        viewModelScope.launch {
-            homeRepository.requestUserNotification({ response ->
-                viewedNotification = response.data.viewed
-                reportNotification = response.data.report
-                marketingNotification = response.data.marketing
-                requestMyInfo()
-            })
-            {
-                isApifinished = true
-            }
-        }
-
-    }
-
-    //사용자 알림설정 update
-    fun updateUserNotification(locationAgreement: Boolean) {
-        val body =
-            NotificationSettings(viewedNotification, reportNotification, marketingNotification)
-        viewModelScope.launch {
-            try {
-                supportApi.updateUserNotification(body)
-                Log.d(TAG, "알림 저장 성공: $body")
-
-                val userInfo = UserInfo(locationConsent = locationAgreement)
-                val response = userApi.userUpdate(userInfo)
-                if (response.isSuccessful) {
-                    Log.d(TAG, "위치서비스 동의 저장 성공: ${response.code()}")
-
-                    _isUpdateUserNotificationApiFinished.value = true
-                }
-            } catch (e: Exception) {
-                e.printStackTrace()
-                Log.d("알림 설정 실패", "${e.message}")
-            }
-        }
-    }
-
-    fun setAlarmFromTimeString(context: Context, hour: String, min: String, period: String) {
-        if (hour.isBlank() || min.isBlank() || period.isBlank()) {
-            Log.e(TAG, "Hour, minute, or period is blank or null.")
-            return
-        }
-
-        val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
-        val intent = Intent(context, AlarmReceiver::class.java)
-        val pendingIntent = PendingIntent.getBroadcast(
-            context,
-            0,
-            intent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-        )
-
-        val calendar = Calendar.getInstance()
-
-        try {
-            // 시간과 분을 설정
-            calendar.set(Calendar.HOUR_OF_DAY, convertTo24HourFormat(hour.toInt(), period))
-            calendar.set(Calendar.MINUTE, min.toInt())
-            calendar.set(Calendar.SECOND, 0)
-
-            // 현재 시간보다 이전이면 다음 날로 설정
-            if (calendar.timeInMillis <= System.currentTimeMillis()) {
-                calendar.add(Calendar.DAY_OF_YEAR, 1)
-            }
-
-            val dateFormat = SimpleDateFormat("hh:mm a", Locale.getDefault())
-            Log.d(TAG, "성공적으로 알람 세팅 완료: ${dateFormat.format(calendar.time)}")
-
-            // 알람 설정 매일 울리게
-            alarmManager.setRepeating(
-                AlarmManager.RTC_WAKEUP,
-                calendar.timeInMillis,
-                AlarmManager.INTERVAL_DAY,
-                pendingIntent
-            )
-        } catch (e: Exception) {
-            Log.e(TAG, "Failed to set alarm", e)
-        }
-    }
-
-    private fun convertTo24HourFormat(hour: Int, period: String): Int {
-        // 오전(AM)과 오후(PM)에 따라 24시간 형식으로 변환
-        return when (period.uppercase(Locale.getDefault())) {
-            "AM" -> if (hour == 12) 0 else hour // 오전 12시는 0시로 변환
-            "PM" -> if (hour == 12) 12 else hour + 12 // 오후 12시는 그대로, 그 외는 12를 더함
-            else -> throw IllegalArgumentException("Invalid period: $period")
-        }
-    }
-
-    fun cancelAlarm(context: Context) {
-        val intent = Intent(context, AlarmReceiver::class.java)
-        val pendingIntent = PendingIntent.getBroadcast(
-            context,
-            0,
-            intent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
-
-            )
-        val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
-        alarmManager.cancel(pendingIntent)
-
-        // 알람이 해제되었음을 로그로 출력
-        Log.d(TAG, "알람 취소")
-    }
-
-    @SuppressLint("ScheduleExactAlarm")
-    fun setAlarmAfter10(context: Context) {
-        val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
-        val intent = Intent(context, AlarmReceiver::class.java)
-        val pendingIntent = PendingIntent.getBroadcast(
-            context,
-            0,
-            intent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-        )
-
-        // 현재 시간에 10초를 추가하여 알람 시간을 설정
-        val triggerTime = System.currentTimeMillis() + 10000 // 10초 후의 시간
-
-        alarmManager.setExact(AlarmManager.RTC_WAKEUP, triggerTime, pendingIntent)
-
-        Log.d(TAG, "Alarm set for 10 seconds later.")
     }
 
     //최신공지 여부

--- a/app/src/main/java/com/echoist/linkedout/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/echoist/linkedout/presentation/home/HomeViewModel.kt
@@ -335,20 +335,6 @@ class HomeViewModel @Inject constructor(
             }
         ) { supportApi.readUpdatedHistories() }
     }
-
-    var essayCount by mutableStateOf(mutableListOf(0, 0, 0, 0, 0))
-
-    //유저 주간 링크드아웃 지수
-    fun requestUserGraphSummary() {
-        viewModelScope.launch {
-            homeRepository.requestUserGraphSummary { response ->
-                repeat(5) {
-                    essayCount[it] = response.data.weeklyEssayCounts!![it].count
-                }
-            }
-        }
-    }
-
     //튜토리얼 건너뛰기
     fun requestFirstUserToExistUser() {
         viewModelScope.launch {

--- a/app/src/main/java/com/echoist/linkedout/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/echoist/linkedout/presentation/home/HomeViewModel.kt
@@ -15,7 +15,6 @@ import com.echoist.linkedout.data.api.SignUpApiImpl
 import com.echoist.linkedout.data.api.SupportApi
 import com.echoist.linkedout.data.api.UserApi
 import com.echoist.linkedout.data.api.apiCall
-import com.echoist.linkedout.data.dto.ExampleItems
 import com.echoist.linkedout.data.dto.Release
 import com.echoist.linkedout.data.dto.UserInfo
 import com.echoist.linkedout.data.repository.HomeRepository
@@ -31,7 +30,6 @@ import javax.inject.Inject
 
 @HiltViewModel
 class HomeViewModel @Inject constructor(
-    private val exampleItems: ExampleItems,
     private val userDataRepository: UserDataRepository,
     private val userApi: UserApi,
     private val supportApi: SupportApi,

--- a/app/src/main/java/com/echoist/linkedout/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/echoist/linkedout/presentation/home/HomeViewModel.kt
@@ -11,7 +11,6 @@ import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.runtime.toMutableStateList
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.echoist.linkedout.data.api.EssayApi
 import com.echoist.linkedout.data.api.SignUpApiImpl
 import com.echoist.linkedout.data.api.SupportApi
 import com.echoist.linkedout.data.api.UserApi
@@ -40,8 +39,6 @@ class HomeViewModel @Inject constructor(
     private val tokenRepository: TokenRepository
 ) : ViewModel() {
 
-    var myProfile by mutableStateOf(exampleItems.myProfile)
-
     var isLoading by mutableStateOf(false)
     var isFirstUser by mutableStateOf(false)
     var latestNoticeId: Int? by mutableStateOf(null) //공지가 있을경우 true, 없을경우 Null
@@ -53,6 +50,7 @@ class HomeViewModel @Inject constructor(
 
     private val _isUserDeleteApiFinished = MutableStateFlow(false)
     val isUserDeleteApiFinished: StateFlow<Boolean> = _isUserDeleteApiFinished
+
     private val _isUpdateUserNotificationApiFinished = MutableStateFlow(false)
 
     private val _isExistLatestUpdate = MutableStateFlow(false)
@@ -68,14 +66,6 @@ class HomeViewModel @Inject constructor(
 
     fun setReAuthenticationRequired(value: Boolean) {
         tokenRepository.setReAuthenticationRequired(value)
-    }
-
-    fun initializeDetailEssay() {
-        exampleItems.detailEssay = EssayApi.EssayItem()
-    }
-
-    fun setStorageEssay(essayItem: EssayApi.EssayItem) {
-        exampleItems.storageEssay = essayItem
     }
 
     suspend fun requestMyInfo() {

--- a/app/src/main/java/com/echoist/linkedout/presentation/home/TabletHomeScreen.kt
+++ b/app/src/main/java/com/echoist/linkedout/presentation/home/TabletHomeScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.NavigationDrawerItem
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -38,11 +37,9 @@ import com.bumptech.glide.integration.compose.GlideImage
 import com.echoist.linkedout.R
 import com.echoist.linkedout.presentation.essay.write.WritingViewModel
 import com.echoist.linkedout.presentation.home.tutorial.TutorialScreen
-import com.echoist.linkedout.presentation.util.Routes
 import com.echoist.linkedout.presentation.util.TUTORIAL_BULB
 import com.echoist.linkedout.presentation.util.UserStatus
 import com.echoist.linkedout.presentation.util.getCurrentDateFormatted
-import com.echoist.linkedout.presentation.util.navigateWithClearBackStack
 
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @OptIn(ExperimentalGlideComposeApi::class)
@@ -66,7 +63,6 @@ fun TabletHomeRoute(
 
     LaunchedEffect(key1 = Unit) {
         viewModel.requestMyInfo()
-        viewModel.requestUserGraphSummary()
         viewModel.requestGuleRoquis()
         viewModel.requestUnreadAlerts()
         viewModel.requestLatestNotice()

--- a/app/src/main/java/com/echoist/linkedout/presentation/home/drawable/DrawableScreen.kt
+++ b/app/src/main/java/com/echoist/linkedout/presentation/home/drawable/DrawableScreen.kt
@@ -38,24 +38,26 @@ import com.echoist.linkedout.presentation.util.navigateWithClearBackStack
 
 @Composable
 fun DrawableScreen(
-    viewModel: DrawableViewModel = hiltViewModel(),
-    navController: NavController,
-    userInfoViewModel: UserInfoViewModel = hiltViewModel()
+        viewModel: DrawableViewModel = hiltViewModel(),
+        navController: NavController,
+        userInfoViewModel: UserInfoViewModel = hiltViewModel()
 ) {
     var isLogoutClicked by remember { mutableStateOf(false) }
+
     val essayCount by viewModel.essayCount.collectAsState()
+    val myInfo by viewModel.getMyInfo().collectAsState()
 
     LaunchedEffect(key1 = Unit) {
         viewModel.requestUserGraphSummary()
     }
 
     ModalDrawerSheet(
-        modifier = Modifier.fillMaxWidth(0.9f),
-        drawerShape = RectangleShape,
-        drawerContainerColor = Color(0xFF121212)
+            modifier = Modifier.fillMaxWidth(0.9f),
+            drawerShape = RectangleShape,
+            drawerContainerColor = Color(0xFF121212)
     ) {
         Column(Modifier.verticalScroll(rememberScrollState())) {
-            MyProfile(item = viewModel.getMyInfo()) { navController.navigate("SETTINGS") }
+            MyProfile(item = myInfo) { navController.navigate("SETTINGS") }
             HorizontalDivider(thickness = 6.dp, color = Color(0xFF191919))
             MyLinkedOutBar()
             LineChartExample(essayCounts = essayCount)
@@ -73,23 +75,23 @@ fun DrawableScreen(
         }
     }
     AnimatedVisibility(
-        visible = isLogoutClicked,
-        enter = slideInVertically(
-            initialOffsetY = { 2000 },
-            animationSpec = tween(durationMillis = 500)
-        ),
-        exit = slideOutVertically(
-            targetOffsetY = { 2000 },
-            animationSpec = tween(durationMillis = 500)
-        )
+            visible = isLogoutClicked,
+            enter = slideInVertically(
+                    initialOffsetY = { 2000 },
+                    animationSpec = tween(durationMillis = 500)
+            ),
+            exit = slideOutVertically(
+                    targetOffsetY = { 2000 },
+                    animationSpec = tween(durationMillis = 500)
+            )
     ) {
         LogoutBox(
-            isCancelClicked = { isLogoutClicked = false },
-            isLogoutClicked = {
-                userInfoViewModel.logout()
-                isLogoutClicked = false
-                navigateWithClearBackStack(navController, Routes.LoginPage)
-            }
+                isCancelClicked = { isLogoutClicked = false },
+                isLogoutClicked = {
+                    userInfoViewModel.logout()
+                    isLogoutClicked = false
+                    navigateWithClearBackStack(navController, Routes.LoginPage)
+                }
         )
     }
 }

--- a/app/src/main/java/com/echoist/linkedout/presentation/home/drawable/DrawableScreen.kt
+++ b/app/src/main/java/com/echoist/linkedout/presentation/home/drawable/DrawableScreen.kt
@@ -13,6 +13,8 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.ModalDrawerSheet
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -23,7 +25,6 @@ import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
-import com.echoist.linkedout.presentation.home.HomeViewModel
 import com.echoist.linkedout.presentation.home.LineChartExample
 import com.echoist.linkedout.presentation.home.LogoutBox
 import com.echoist.linkedout.presentation.home.LogoutBtn
@@ -37,23 +38,27 @@ import com.echoist.linkedout.presentation.util.navigateWithClearBackStack
 
 @Composable
 fun DrawableScreen(
-    viewModel: HomeViewModel,
+    viewModel: DrawableViewModel = hiltViewModel(),
     navController: NavController,
     userInfoViewModel: UserInfoViewModel = hiltViewModel()
 ) {
     var isLogoutClicked by remember { mutableStateOf(false) }
-    val scrollState = rememberScrollState()
+    val essayCount by viewModel.essayCount.collectAsState()
+
+    LaunchedEffect(key1 = Unit) {
+        viewModel.requestUserGraphSummary()
+    }
 
     ModalDrawerSheet(
         modifier = Modifier.fillMaxWidth(0.9f),
         drawerShape = RectangleShape,
         drawerContainerColor = Color(0xFF121212)
     ) {
-        Column(Modifier.verticalScroll(scrollState)) {
+        Column(Modifier.verticalScroll(rememberScrollState())) {
             MyProfile(item = viewModel.getMyInfo()) { navController.navigate("SETTINGS") }
             HorizontalDivider(thickness = 6.dp, color = Color(0xFF191919))
             MyLinkedOutBar()
-            LineChartExample(essayCounts = viewModel.essayCount)
+            LineChartExample(essayCounts = essayCount)
             Spacer(modifier = Modifier.height(10.dp))
             HorizontalDivider(thickness = 6.dp, color = Color(0xFF191919))
             ShopDrawerItem()

--- a/app/src/main/java/com/echoist/linkedout/presentation/home/drawable/DrawableViewModel.kt
+++ b/app/src/main/java/com/echoist/linkedout/presentation/home/drawable/DrawableViewModel.kt
@@ -1,0 +1,36 @@
+package com.echoist.linkedout.presentation.home.drawable
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.echoist.linkedout.data.dto.ExampleItems
+import com.echoist.linkedout.data.dto.UserInfo
+import com.echoist.linkedout.data.repository.HomeRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class DrawableViewModel @Inject constructor(
+        private val exampleItems: ExampleItems,
+        private val homeRepository: HomeRepository,
+) : ViewModel() {
+
+    private val _essayCount = MutableStateFlow(List(5) { 0 }) //초기값 0,0,0,0,0
+    val essayCount: StateFlow<List<Int>> = _essayCount
+
+    // 유저 주간 링크드아웃 지수
+    fun requestUserGraphSummary() {
+        viewModelScope.launch {
+            homeRepository.requestUserGraphSummary { response ->
+                val updatedCounts = response.data.weeklyEssayCounts!!.map { it.count }
+                _essayCount.value = updatedCounts
+            }
+        }
+    }
+
+    fun getMyInfo(): UserInfo { // 함수 이름 변경
+        return exampleItems.myProfile
+    }
+}

--- a/app/src/main/java/com/echoist/linkedout/presentation/home/drawable/DrawableViewModel.kt
+++ b/app/src/main/java/com/echoist/linkedout/presentation/home/drawable/DrawableViewModel.kt
@@ -1,19 +1,17 @@
 package com.echoist.linkedout.presentation.home.drawable
 
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
-import com.echoist.linkedout.data.dto.ExampleItems
 import com.echoist.linkedout.data.dto.UserInfo
 import com.echoist.linkedout.data.repository.HomeRepository
+import com.echoist.linkedout.data.repository.UserDataRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class DrawableViewModel @Inject constructor(
-        private val exampleItems: ExampleItems,
+        private val userDataRepository: UserDataRepository,
         private val homeRepository: HomeRepository,
 ) : ViewModel() {
 
@@ -21,16 +19,14 @@ class DrawableViewModel @Inject constructor(
     val essayCount: StateFlow<List<Int>> = _essayCount
 
     // 유저 주간 링크드아웃 지수
-    fun requestUserGraphSummary() {
-        viewModelScope.launch {
-            homeRepository.requestUserGraphSummary { response ->
-                val updatedCounts = response.data.weeklyEssayCounts!!.map { it.count }
-                _essayCount.value = updatedCounts
-            }
+    suspend fun requestUserGraphSummary() {
+        homeRepository.requestUserGraphSummary { response ->
+            val updatedCounts = response.data.weeklyEssayCounts!!.map { it.count }
+            _essayCount.value = updatedCounts
         }
     }
 
-    fun getMyInfo(): UserInfo { // 함수 이름 변경
-        return exampleItems.myProfile
+    fun getMyInfo(): StateFlow<UserInfo> { // 함수 이름 변경
+        return userDataRepository.userInfo
     }
 }

--- a/app/src/main/java/com/echoist/linkedout/presentation/home/drawable/DrawableViewModel.kt
+++ b/app/src/main/java/com/echoist/linkedout/presentation/home/drawable/DrawableViewModel.kt
@@ -26,7 +26,7 @@ class DrawableViewModel @Inject constructor(
         }
     }
 
-    fun getMyInfo(): StateFlow<UserInfo> { // 함수 이름 변경
+    fun getMyInfo(): StateFlow<UserInfo> {
         return userDataRepository.userInfo
     }
 }

--- a/app/src/main/java/com/echoist/linkedout/presentation/home/drawable/TabletDrawableScreen.kt
+++ b/app/src/main/java/com/echoist/linkedout/presentation/home/drawable/TabletDrawableScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavController
 import com.echoist.linkedout.data.dto.UserInfo
 import com.echoist.linkedout.presentation.home.LineChartExample
 import com.echoist.linkedout.presentation.home.LogoutBtn
@@ -49,6 +48,7 @@ fun TabletDrawableScreen(
 ) {
     var selectedMenu by remember { mutableStateOf(selectedMenu) }
     var noticeId by remember { mutableStateOf(0) }
+
 
     Row {
         Column(

--- a/app/src/main/java/com/echoist/linkedout/presentation/home/drawable/setting/NotificationSettingScreen.kt
+++ b/app/src/main/java/com/echoist/linkedout/presentation/home/drawable/setting/NotificationSettingScreen.kt
@@ -52,19 +52,22 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import com.echoist.linkedout.R
-import com.echoist.linkedout.presentation.home.HomeViewModel
 import com.echoist.linkedout.presentation.home.notification.ImageSwitch
 import com.echoist.linkedout.presentation.home.notification.NotificationViewModel
 import com.echoist.linkedout.presentation.userInfo.account.SettingTopAppBar
+import com.echoist.linkedout.presentation.util.Routes
+import com.echoist.linkedout.presentation.util.navigateWithClearBackStack
 import com.echoist.linkedout.ui.theme.LinkedInColor
 
 @Composable
 fun NotificationSettingScreen(
     navController: NavController,
-    homeViewModel: HomeViewModel = hiltViewModel(),
     notificationViewModel: NotificationViewModel = hiltViewModel()
 ) {
-    homeViewModel.readUserNotification()
+
+    LaunchedEffect(key1 = Unit) {
+        notificationViewModel.readUserNotification()
+    }
     val context = LocalContext.current
 
     val hour by notificationViewModel.hour.collectAsState()
@@ -79,13 +82,13 @@ fun NotificationSettingScreen(
         content = {
             var isClickedTimeSelection by remember { mutableStateOf(false) }
 
-            if (homeViewModel.isApifinished) {
+            if (notificationViewModel.isApifinished) {
                 Column(
-                    Modifier
-                        .padding(it)
-                        .navigationBarsPadding()
-                        .padding(bottom = 20.dp)
-                        .verticalScroll(rememberScrollState())
+                        Modifier
+                                .padding(it)
+                                .navigationBarsPadding()
+                                .padding(bottom = 20.dp)
+                                .verticalScroll(rememberScrollState())
                 ) {
 
                     Text(
@@ -99,17 +102,17 @@ fun NotificationSettingScreen(
                     EssayNotificationBox(
                         "글 ",
                         "조회 알림",
-                        homeViewModel.viewedNotification
+                            notificationViewModel.viewedNotification
                     ) { it ->
-                        homeViewModel.viewedNotification = it
+                        notificationViewModel.viewedNotification = it
                     }
 
                     EssayNotificationBox(
                         "신고 결과",
                         "알림",
-                        homeViewModel.reportNotification
+                            notificationViewModel.reportNotification
                     ) { it ->
-                        homeViewModel.reportNotification = it
+                        notificationViewModel.reportNotification = it
                     }
 
                     Spacer(modifier = Modifier.height(20.dp))
@@ -143,9 +146,9 @@ fun NotificationSettingScreen(
                     EssayNotificationBox(
                         "이벤트 혜택 ",
                         "정보 알림",
-                        homeViewModel.marketingNotification
+                            notificationViewModel.marketingNotification
                     ) { it ->
-                        homeViewModel.marketingNotification = it
+                        notificationViewModel.marketingNotification = it
                         Log.d(TAG, "NotificationPage: $it")
                     }
                     Spacer(modifier = Modifier.height(20.dp))
@@ -161,9 +164,9 @@ fun NotificationSettingScreen(
                     EssayNotificationBox(
                         "위치 기반 서비스 ",
                         "동의",
-                        homeViewModel.locationNotification
+                        notificationViewModel.locationNotification
                     ) { it ->
-                        homeViewModel.locationNotification = it
+                        notificationViewModel.locationNotification = it
                         Log.d(TAG, "NotificationPage: $it")
                     }
                     Spacer(modifier = Modifier.height(20.dp))
@@ -189,29 +192,30 @@ fun NotificationSettingScreen(
             }
             Box(
                 modifier = Modifier
-                    .fillMaxSize()
-                    .padding(horizontal = 20.dp)
-                    .padding(bottom = 60.dp), contentAlignment = Alignment.BottomCenter
+                        .fillMaxSize()
+                        .padding(horizontal = 20.dp)
+                        .padding(bottom = 60.dp), contentAlignment = Alignment.BottomCenter
             ) {
                 Button(modifier = Modifier
-                    .fillMaxWidth()
-                    .height(61.dp), shape = RoundedCornerShape(20),
+                        .fillMaxWidth()
+                        .height(61.dp), shape = RoundedCornerShape(20),
                     onClick = {
-                        homeViewModel.updateUserNotification(
-                            homeViewModel.locationNotification
+                        navigateWithClearBackStack(navController,"${Routes.Home}/200")
+                        notificationViewModel.updateUserNotification(
+                                notificationViewModel.locationNotification
                         )
                         notificationViewModel.saveWritingRemindNotification(
                             writingRemindNotification
                         ) //글쓰기 시간 알림 설정 저장
                         if (writingRemindNotification) {
-                            homeViewModel.setAlarmFromTimeString(
+                            notificationViewModel.setAlarmFromTimeString(
                                 context = context,
                                 hour,
                                 min,
                                 period
                             ) //정해진 시간에 알람설정.
                         } else {
-                            homeViewModel.cancelAlarm(context) //알람 취소
+                            notificationViewModel.cancelAlarm(context) //알람 취소
                         }
                     }) {
                     Text(text = "저장", color = Color.Black)
@@ -230,10 +234,10 @@ fun EssayNotificationBox(
 ) {
     Box(
         modifier = Modifier
-            .fillMaxWidth()
-            .background(Color(0xFF0E0E0E))
-            .height(58.dp)
-            .padding(horizontal = 20.dp)
+                .fillMaxWidth()
+                .background(Color(0xFF0E0E0E))
+                .height(58.dp)
+                .padding(horizontal = 20.dp)
     ) {
         Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.CenterStart) {
             Row {
@@ -275,15 +279,15 @@ fun WritingNotificationBox(
 ) {
     Box(
         modifier = Modifier
-            .fillMaxWidth()
-            .background(Color(0xFF0E0E0E), shape = RoundedCornerShape(6))
-            .height(120.dp)
-            .padding(horizontal = 20.dp)
+                .fillMaxWidth()
+                .background(Color(0xFF0E0E0E), shape = RoundedCornerShape(6))
+                .height(120.dp)
+                .padding(horizontal = 20.dp)
     ) {
         Box(
             modifier = Modifier
-                .fillMaxSize()
-                .padding(top = 20.dp), contentAlignment = Alignment.TopStart
+                    .fillMaxSize()
+                    .padding(top = 20.dp), contentAlignment = Alignment.TopStart
         ) {
             Row {
                 Text(text = "글쓰기 시간 알림 설정", color = Color.White)
@@ -291,8 +295,8 @@ fun WritingNotificationBox(
         }
         Box(
             modifier = Modifier
-                .fillMaxSize()
-                .padding(top = 10.dp), contentAlignment = Alignment.TopEnd
+                    .fillMaxSize()
+                    .padding(top = 10.dp), contentAlignment = Alignment.TopEnd
         ) {
             ImageSwitch(
                 height = 26.dp,
@@ -314,14 +318,14 @@ fun WritingNotificationBox(
         }
         Box(
             modifier = Modifier
-                .fillMaxSize()
-                .padding(bottom = 20.dp), contentAlignment = Alignment.BottomEnd
+                    .fillMaxSize()
+                    .padding(bottom = 20.dp), contentAlignment = Alignment.BottomEnd
         ) {
             Box(
                 modifier = Modifier
-                    .size(90.dp, 34.dp)
-                    .clickable { isTimeSelectionClicked() }
-                    .background(Color(0xFF222222)), contentAlignment = Alignment.Center
+                        .size(90.dp, 34.dp)
+                        .clickable { isTimeSelectionClicked() }
+                        .background(Color(0xFF222222)), contentAlignment = Alignment.Center
             ) {
                 Text(text = "${hour}:${min} $period", color = Color(0xFF979797))
             }
@@ -340,15 +344,15 @@ fun NotificationTimePickerBox(
 
     Box(
         modifier = Modifier
-            .fillMaxSize()
-            .background(Color.Black.copy(0.7f)),
+                .fillMaxSize()
+                .background(Color.Black.copy(0.7f)),
         contentAlignment = Alignment.Center
     ) {
         Box(
             modifier = Modifier
-                .background(Color(0xFF212121), shape = RoundedCornerShape(5))
-                .size(299.dp, 286.dp)
-                .padding(horizontal = 20.dp, vertical = 20.dp)
+                    .background(Color(0xFF212121), shape = RoundedCornerShape(5))
+                    .size(299.dp, 286.dp)
+                    .padding(horizontal = 20.dp, vertical = 20.dp)
         ) {
             Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.TopCenter) {
                 Text(text = "알림 허용 시간", color = Color.White)
@@ -365,8 +369,8 @@ fun NotificationTimePickerBox(
             }
             Box(
                 modifier = Modifier
-                    .fillMaxSize()
-                    .padding(bottom = 20.dp),
+                        .fillMaxSize()
+                        .padding(bottom = 20.dp),
                 contentAlignment = Alignment.Center
             ) {
                 NotificationTimePicker(
@@ -385,8 +389,8 @@ fun NotificationTimePickerBox(
                         }
                     },
                     modifier = Modifier
-                        .height(50.dp)
-                        .fillMaxWidth(),
+                            .height(50.dp)
+                            .fillMaxWidth(),
                     shape = RoundedCornerShape(20)
                 ) {
                     Text(text = "저장", color = Color.Black)
@@ -415,30 +419,30 @@ fun NotificationTimePicker(
                 imageVector = Icons.Default.KeyboardArrowUp,
                 contentDescription = "Increase time period",
                 modifier = Modifier
-                    .weight(1f)
-                    .clickable {
-                        timePeriodIndex = (timePeriodIndex + 1) % timePeriods.size
-                    },
+                        .weight(1f)
+                        .clickable {
+                            timePeriodIndex = (timePeriodIndex + 1) % timePeriods.size
+                        },
                 tint = Color.White
             )
             Icon(
                 imageVector = Icons.Default.KeyboardArrowUp,
                 contentDescription = "Increase hour",
                 modifier = Modifier
-                    .weight(1f)
-                    .clickable {
-                        hourIndex = (hourIndex + 1) % hours.size
-                    },
+                        .weight(1f)
+                        .clickable {
+                            hourIndex = (hourIndex + 1) % hours.size
+                        },
                 tint = Color.White
             )
             Icon(
                 imageVector = Icons.Default.KeyboardArrowUp,
                 contentDescription = "Increase minute",
                 modifier = Modifier
-                    .weight(1f)
-                    .clickable {
-                        minuteIndex = (minuteIndex + 1) % minutes.size
-                    },
+                        .weight(1f)
+                        .clickable {
+                            minuteIndex = (minuteIndex + 1) % minutes.size
+                        },
                 tint = Color.White
             )
         }
@@ -465,31 +469,31 @@ fun NotificationTimePicker(
                 imageVector = Icons.Default.KeyboardArrowDown,
                 contentDescription = "Decrease time period",
                 modifier = Modifier
-                    .weight(1f)
-                    .clickable {
-                        timePeriodIndex =
-                            (timePeriodIndex - 1 + timePeriods.size) % timePeriods.size
-                    },
+                        .weight(1f)
+                        .clickable {
+                            timePeriodIndex =
+                                    (timePeriodIndex - 1 + timePeriods.size) % timePeriods.size
+                        },
                 tint = Color.White
             )
             Icon(
                 imageVector = Icons.Default.KeyboardArrowDown,
                 contentDescription = "Decrease hour",
                 modifier = Modifier
-                    .weight(1f)
-                    .clickable {
-                        hourIndex = (hourIndex - 1 + hours.size) % hours.size
-                    },
+                        .weight(1f)
+                        .clickable {
+                            hourIndex = (hourIndex - 1 + hours.size) % hours.size
+                        },
                 tint = Color.White
             )
             Icon(
                 imageVector = Icons.Default.KeyboardArrowDown,
                 contentDescription = "Decrease minute",
                 modifier = Modifier
-                    .weight(1f)
-                    .clickable {
-                        minuteIndex = (minuteIndex - 1 + minutes.size) % minutes.size
-                    },
+                        .weight(1f)
+                        .clickable {
+                            minuteIndex = (minuteIndex - 1 + minutes.size) % minutes.size
+                        },
                 tint = Color.White
             )
         }
@@ -509,11 +513,11 @@ fun NotificationTimePicker(
 fun TimeBox(text: String) {
     Box(
         modifier = Modifier
-            .size(70.dp, 48.dp)
-            .border(
-                BorderStroke(1.dp, Color(0xFF313131)),
-                shape = RoundedCornerShape(20.dp)
-            ),
+                .size(70.dp, 48.dp)
+                .border(
+                        BorderStroke(1.dp, Color(0xFF313131)),
+                        shape = RoundedCornerShape(20.dp)
+                ),
         contentAlignment = Alignment.Center
     ) {
         Text(

--- a/app/src/main/java/com/echoist/linkedout/presentation/home/drawable/setting/TabletSettingScreen.kt
+++ b/app/src/main/java/com/echoist/linkedout/presentation/home/drawable/setting/TabletSettingScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -34,16 +35,17 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.echoist.linkedout.presentation.TabletDrawableTopBar
-import com.echoist.linkedout.presentation.home.HomeViewModel
 import com.echoist.linkedout.presentation.home.notification.NotificationViewModel
 
 @Composable
 fun TabletSettingRoute(
-    viewModel: HomeViewModel = hiltViewModel(),
     notificationViewModel: NotificationViewModel = hiltViewModel(),
     onCloseClick: () -> Unit
 ) {
-    viewModel.readUserNotification()
+
+    LaunchedEffect(key1 = Unit) {
+        notificationViewModel.readUserNotification()
+    }
 
     val context = LocalContext.current
     val hour by notificationViewModel.hour.collectAsState()
@@ -52,7 +54,7 @@ fun TabletSettingRoute(
     val writingRemindNotification by notificationViewModel.writingRemindNotification.collectAsState()
 
     var isClickedTimeSelection by remember { mutableStateOf(false) }
-    if (viewModel.isApifinished) {
+    if (notificationViewModel.isApifinished) {
         Column(
             Modifier
                 .background(Color.Black)
@@ -63,9 +65,9 @@ fun TabletSettingRoute(
                 onCloseClick()
             }
             ReadNotificationSettings(
-                viewModel,
-                onReadNotificationChange = { viewModel.viewedNotification = it },
-                onReportResultNotificationChange = { viewModel.reportNotification = it }
+                    notificationViewModel,
+                onReadNotificationChange = { notificationViewModel.viewedNotification = it },
+                onReportResultNotificationChange = { notificationViewModel.reportNotification = it }
             )
             Spacer(modifier = Modifier.height(20.dp))
             WriteNotificationSettings(
@@ -79,13 +81,13 @@ fun TabletSettingRoute(
                 hour, min, period
             )
             Spacer(modifier = Modifier.height(20.dp))
-            OtherNotificationSettings(viewModel = viewModel) {
-                viewModel.marketingNotification = it
+            OtherNotificationSettings(viewModel = notificationViewModel) {
+                notificationViewModel.marketingNotification = it
             }
             Spacer(modifier = Modifier.height(20.dp))
             LocationServiceSettings(
-                viewModel,
-                onLocationNotificationChange = { viewModel.locationNotification = it }
+                    notificationViewModel,
+                onLocationNotificationChange = { notificationViewModel.locationNotification = it }
             )
         }
         Box(
@@ -98,21 +100,21 @@ fun TabletSettingRoute(
                 .fillMaxWidth()
                 .height(61.dp), shape = RoundedCornerShape(20),
                 onClick = {
-                    viewModel.updateUserNotification(
-                        viewModel.locationNotification
+                    notificationViewModel.updateUserNotification(
+                            notificationViewModel.locationNotification
                     )
                     notificationViewModel.saveWritingRemindNotification(
                         writingRemindNotification
                     ) //글쓰기 시간 알림 설정 저장
                     if (writingRemindNotification) {
-                        viewModel.setAlarmFromTimeString(
+                        notificationViewModel.setAlarmFromTimeString(
                             context = context,
                             hour,
                             min,
                             period
                         ) //정해진 시간에 알람설정.
                     } else {
-                        viewModel.cancelAlarm(context) //알람 취소
+                        notificationViewModel.cancelAlarm(context) //알람 취소
                     }
                 }) {
                 Text(text = "저장", color = Color.Black)
@@ -146,7 +148,7 @@ fun TabletSettingRoute(
 
 @Composable
 fun ReadNotificationSettings(
-    viewModel: HomeViewModel,
+        notificationViewModel: NotificationViewModel,
     onReadNotificationChange: (Boolean) -> Unit,
     onReportResultNotificationChange: (Boolean) -> Unit
 ) {
@@ -160,14 +162,14 @@ fun ReadNotificationSettings(
     EssayNotificationBox(
         "글 ",
         "조회 알림",
-        viewModel.viewedNotification
+            notificationViewModel.viewedNotification
     ) {
         onReadNotificationChange(it)
     }
     EssayNotificationBox(
         "신고 결과",
         "알림",
-        viewModel.reportNotification
+            notificationViewModel.reportNotification
     ) {
         onReportResultNotificationChange(it)
     }
@@ -201,7 +203,7 @@ fun WriteNotificationSettings(
 
 @Composable
 fun OtherNotificationSettings(
-    viewModel: HomeViewModel,
+    viewModel: NotificationViewModel,
     onOtherNotificationChange: (Boolean) -> Unit
 ) {
     Text(
@@ -222,7 +224,7 @@ fun OtherNotificationSettings(
 
 @Composable
 fun LocationServiceSettings(
-    viewModel: HomeViewModel,
+    viewModel: NotificationViewModel,
     onLocationNotificationChange: (Boolean) -> Unit
 ) {
     Text(

--- a/app/src/main/java/com/echoist/linkedout/presentation/home/notification/NotificationViewModel.kt
+++ b/app/src/main/java/com/echoist/linkedout/presentation/home/notification/NotificationViewModel.kt
@@ -1,7 +1,21 @@
 package com.echoist.linkedout.presentation.home.notification
 
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.ContentValues
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.echoist.linkedout.AlarmReceiver
+import com.echoist.linkedout.data.api.SupportApi
+import com.echoist.linkedout.data.api.UserApi
+import com.echoist.linkedout.data.dto.NotificationSettings
+import com.echoist.linkedout.data.dto.UserInfo
 import com.echoist.linkedout.data.repository.UserDataRepository
 import com.echoist.linkedout.presentation.home.drawable.setting.TimeSelectionIndex
 import com.echoist.linkedout.presentation.util.getHourString
@@ -13,27 +27,39 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Locale
 import javax.inject.Inject
 
 @HiltViewModel
 class NotificationViewModel @Inject constructor(
-    private val userDataRepository: UserDataRepository
+        private val userDataRepository: UserDataRepository,
+        private val supportApi: SupportApi,
+        private val userApi: UserApi
 ) : ViewModel() {
 
     private val _timeSelection = MutableStateFlow(userDataRepository.getTimeSelection())
 
     private val _writingRemindNotification =
-        MutableStateFlow(userDataRepository.getWritingRemindNotification())
+            MutableStateFlow(userDataRepository.getWritingRemindNotification())
     val writingRemindNotification: StateFlow<Boolean> = _writingRemindNotification
 
     val hour: StateFlow<String> = _timeSelection.map { getHourString(it.hourIndex) }
-        .stateIn(viewModelScope, SharingStarted.Lazily, "")
+            .stateIn(viewModelScope, SharingStarted.Lazily, "")
 
     val min: StateFlow<String> = _timeSelection.map { getMinuteString(it.minuteIndex) }
-        .stateIn(viewModelScope, SharingStarted.Lazily, "")
+            .stateIn(viewModelScope, SharingStarted.Lazily, "")
 
     val period: StateFlow<String> = _timeSelection.map { getPeriodString(it.periodIndex) }
-        .stateIn(viewModelScope, SharingStarted.Lazily, "")
+            .stateIn(viewModelScope, SharingStarted.Lazily, "")
+
+    var viewedNotification by mutableStateOf(false)
+    var reportNotification by mutableStateOf(false)
+    var marketingNotification by mutableStateOf(false)
+    var locationNotification by mutableStateOf(false)
+
 
     fun updateTimeSelection() {
         _timeSelection.value = userDataRepository.getTimeSelection()
@@ -53,6 +79,131 @@ class NotificationViewModel @Inject constructor(
 
     fun saveTimeSelection(time: TimeSelectionIndex) {
         userDataRepository.saveTimeSelection(time)
+    }
+
+    var isApifinished by mutableStateOf(false)
+
+    private suspend fun requestMyInfo() {
+        try {
+            val response = userApi.getMyInfo()
+            val userinfo = response.data.user.apply {
+                essayStats = response.data.essayStats
+            }
+
+            userDataRepository.setUserInfo(userinfo)
+            Log.i(ContentValues.TAG, "readMyInfo: ${userDataRepository.userInfo}")
+            locationNotification = userinfo.locationConsent ?: false
+
+            //첫유저인지 판별
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+    }
+
+    suspend fun readUserNotification() {
+        try {
+            val response = supportApi.readUserNotification()
+            if (response.isSuccessful) {
+                viewedNotification = response.body()!!.data.viewed
+                reportNotification = response.body()!!.data.report
+                marketingNotification = response.body()!!.data.marketing
+                requestMyInfo()
+            }
+
+        } catch (e: Exception) {
+            e.printStackTrace()
+            Log.d("알림 설정 실패", "${e.message}")
+        } finally {
+            isApifinished = true
+        }
+    }
+    //사용자 알림설정 update
+    fun updateUserNotification(locationAgreement: Boolean) {
+        val body =
+                NotificationSettings(viewedNotification, reportNotification, marketingNotification)
+        viewModelScope.launch {
+            try {
+                supportApi.updateUserNotification(body)
+                Log.d(ContentValues.TAG, "알림 저장 성공: $body")
+
+                val userInfo = UserInfo(locationConsent = locationAgreement)
+                val response = userApi.userUpdate(userInfo)
+                if (response.isSuccessful) {
+                    Log.d(ContentValues.TAG, "위치서비스 동의 저장 성공: ${response.code()}")
+                }
+            } catch (e: Exception) {
+                e.printStackTrace()
+                Log.d("알림 설정 실패", "${e.message}")
+            }
+        }
+    }
+
+    fun setAlarmFromTimeString(context: Context, hour: String, min: String, period: String) {
+        if (hour.isBlank() || min.isBlank() || period.isBlank()) {
+            Log.e(ContentValues.TAG, "Hour, minute, or period is blank or null.")
+            return
+        }
+
+        val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+        val intent = Intent(context, AlarmReceiver::class.java)
+        val pendingIntent = PendingIntent.getBroadcast(
+                context,
+                0,
+                intent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val calendar = Calendar.getInstance()
+
+        try {
+            // 시간과 분을 설정
+            calendar.set(Calendar.HOUR_OF_DAY, convertTo24HourFormat(hour.toInt(), period))
+            calendar.set(Calendar.MINUTE, min.toInt())
+            calendar.set(Calendar.SECOND, 0)
+
+            // 현재 시간보다 이전이면 다음 날로 설정
+            if (calendar.timeInMillis <= System.currentTimeMillis()) {
+                calendar.add(Calendar.DAY_OF_YEAR, 1)
+            }
+
+            val dateFormat = SimpleDateFormat("hh:mm a", Locale.getDefault())
+            Log.d(ContentValues.TAG, "성공적으로 알람 세팅 완료: ${dateFormat.format(calendar.time)}")
+
+            // 알람 설정 매일 울리게
+            alarmManager.setRepeating(
+                    AlarmManager.RTC_WAKEUP,
+                    calendar.timeInMillis,
+                    AlarmManager.INTERVAL_DAY,
+                    pendingIntent
+            )
+        } catch (e: Exception) {
+            Log.e(ContentValues.TAG, "Failed to set alarm", e)
+        }
+    }
+
+    private fun convertTo24HourFormat(hour: Int, period: String): Int {
+        // 오전(AM)과 오후(PM)에 따라 24시간 형식으로 변환
+        return when (period.uppercase(Locale.getDefault())) {
+            "AM" -> if (hour == 12) 0 else hour // 오전 12시는 0시로 변환
+            "PM" -> if (hour == 12) 12 else hour + 12 // 오후 12시는 그대로, 그 외는 12를 더함
+            else -> throw IllegalArgumentException("Invalid period: $period")
+        }
+    }
+
+    fun cancelAlarm(context: Context) {
+        val intent = Intent(context, AlarmReceiver::class.java)
+        val pendingIntent = PendingIntent.getBroadcast(
+                context,
+                0,
+                intent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+
+                )
+        val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+        alarmManager.cancel(pendingIntent)
+
+        // 알람이 해제되었음을 로그로 출력
+        Log.d(ContentValues.TAG, "알람 취소")
     }
 
 }

--- a/app/src/main/java/com/echoist/linkedout/presentation/login/signup/SignUpComplete.kt
+++ b/app/src/main/java/com/echoist/linkedout/presentation/login/signup/SignUpComplete.kt
@@ -17,6 +17,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -54,17 +55,18 @@ fun SignUpCompletePage(homeViewModel: HomeViewModel = hiltViewModel(), navContro
         }
     }
 
+    val myInfo by homeViewModel.getMyInfo().collectAsState()
+
     Scaffold {
         Box(
-            Modifier
-                .padding(it)
-                .fillMaxSize(), contentAlignment = Alignment.Center
+                Modifier
+                        .padding(it).fillMaxSize(), contentAlignment = Alignment.Center
         ) {
             Column(
                 Modifier.padding(horizontal = 20.dp),
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
-                LoadingText(nickName = homeViewModel.readMyProfile().nickname!!)
+                LoadingText(nickName = myInfo.nickname ?: "아무개")
                 Spacer(modifier = Modifier.height(56.dp))
                 GlideImage(
                     model = R.drawable.login_table,
@@ -76,15 +78,15 @@ fun SignUpCompletePage(homeViewModel: HomeViewModel = hiltViewModel(), navContro
             }
             Box(
                 modifier = Modifier
-                    .fillMaxSize()
-                    .padding(end = 20.dp), contentAlignment = Alignment.BottomEnd
+                        .fillMaxSize()
+                        .padding(end = 20.dp), contentAlignment = Alignment.BottomEnd
             ) {
                 GlideImage(
                     model = R.drawable.rightsidetext,
                     contentDescription = "rightsideText",
-                    Modifier
-                        .padding(bottom = 80.dp)
-                        .size(240.dp, 90.dp)
+                        Modifier
+                                .padding(bottom = 80.dp)
+                                .size(240.dp, 90.dp)
                 )
             }
         }
@@ -138,8 +140,8 @@ fun LoadingText(nickName: String) {
 fun RightSideText() {
     Box(
         modifier = Modifier
-            .fillMaxWidth()
-            .height(90.dp)
+                .fillMaxWidth()
+                .height(90.dp)
     ) {
         Text(
             text = "이곳에서 마음껏\n실험하고,부딪히고,성장하는\n아무개가 되어보세요 ",

--- a/app/src/main/java/com/echoist/linkedout/presentation/login/signup/TabletSignUpCompleteScreen.kt
+++ b/app/src/main/java/com/echoist/linkedout/presentation/login/signup/TabletSignUpCompleteScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -47,10 +48,11 @@ fun TabletSignUpCompleteRoute(
         isLoading = false
         navigateToHome()
     }
+    val myInfo by viewModel.getMyInfo().collectAsState()
 
     TabletSignUpCompleteScreen(
         isLoading = isLoading,
-        nickName = viewModel.readMyProfile().nickname,
+        nickName = myInfo.nickname,
         horizontalPadding = if (configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) 350 else 100,
     )
 }

--- a/app/src/main/java/com/echoist/linkedout/presentation/myLog/mylog/MyLogPage.kt
+++ b/app/src/main/java/com/echoist/linkedout/presentation/myLog/mylog/MyLogPage.kt
@@ -120,7 +120,6 @@ fun MyLogPage(
                         floatingActionButton = {
                             WriteFTB(
                                 navController,
-                                homeViewModel,
                                 writingViewModel
                             )
                         },

--- a/app/src/main/java/com/echoist/linkedout/presentation/util/CommonUtils.kt
+++ b/app/src/main/java/com/echoist/linkedout/presentation/util/CommonUtils.kt
@@ -1,15 +1,19 @@
 package com.echoist.linkedout.presentation.util
 
 import android.content.ContentResolver
+import android.content.ContentValues
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.provider.OpenableColumns
+import android.provider.Settings
+import android.util.Log
 import androidx.core.content.ContextCompat
 import androidx.navigation.NavController
 import com.echoist.linkedout.BuildConfig
 import com.echoist.linkedout.presentation.essay.write.WritingViewModel
+import com.google.firebase.messaging.FirebaseMessaging
 import java.io.File
 import java.io.FileOutputStream
 import java.io.InputStream
@@ -172,5 +176,26 @@ fun formatElapsedTime(isoDateTimeString: String): String {
         hours > 0 -> "${hours}시간 전"
         minutes > 0 -> "${minutes}분 전"
         else -> "${seconds}초 전"
+    }
+}
+
+//안드로이드 고유식별자
+fun getSSAID(context: Context): String {
+    val deviceId =
+            Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
+    Log.d("DeviceID", "Device ID: $deviceId")
+    return deviceId
+}
+//fcm토큰
+fun getFCMToken(callback: (String?) -> Unit) {
+    FirebaseMessaging.getInstance().token.addOnCompleteListener { task ->
+        if (!task.isSuccessful) {
+            Log.w(ContentValues.TAG, "Fetching FCM registration token failed", task.exception)
+            callback(null) // 작업 실패 시 null 반환
+            return@addOnCompleteListener
+        }
+        // Get new FCM registration token
+        val token = task.result
+        callback(token)
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> homeViewModel에서 exampleItems제거
> userInfo 를 UserDataRepository에서만 상태처리하게끔 수정

exampleItems를 한번에 제거하는게 무리인 것 같아서 writingViewModel에서 
exampleItems.detailEssay와 exampleItems.storageEssay를 초기화하게끔 수정하여 일단 home뷰모델에서 제거하였습니다.


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `DrawableViewModel` for managing drawable-related data.
	- Added new functionality for handling user notifications in the `NotificationViewModel`.
	- Enhanced user information management in the `UserDataRepository`.
	- Implemented reactive data handling for user information display in the `SignUpComplete` and `TabletSignUpCompleteScreen`.

- **Bug Fixes**
	- Streamlined data fetching logic in various components to improve performance and reliability.

- **Refactor**
	- Removed unnecessary parameters and dependencies in several composable functions, simplifying the codebase.

- **Documentation**
	- Updated comments and method signatures for clarity and consistency across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->